### PR TITLE
Add control for hyperlink underline

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -324,6 +324,7 @@ Host::Host(int port, const QString& hostname, const QString& login, const QStrin
 , mPlayerRoomInnerDiameterPercentage(70)
 , mDebugShowAllProblemCodepoints(false)
 , mCompactInputLine(false)
+, mUnderlineHyperlinks(true)
 {
     TDebug::addHost(this, mHostName);
 
@@ -3087,6 +3088,11 @@ void Host::setCompactInputLine(const bool state)
             mpConsole->mpButtonMainLayer->setVisible(!state);
         }
     }
+}
+
+void Host::setUnderlineHyperlinks(bool state)
+{
+    mUnderlineHyperlinks = state;
 }
 
 QPointer<TConsole> Host::findConsole(QString name)

--- a/src/Host.h
+++ b/src/Host.h
@@ -214,6 +214,8 @@ public:
     ControlCharacterMode  getControlCharacterMode() const { return mControlCharacter; }
     bool            getLargeAreaExitArrows() const { return mLargeAreaExitArrows; }
     void            setLargeAreaExitArrows(const bool);
+    bool            getUnderlineHyperlinks() const { return mUnderlineHyperlinks; }
+    void            setUnderlineHyperlinks(bool);
 
     void            forceClose();
     bool            isClosingDown() const { return mIsClosingDown; }
@@ -904,6 +906,7 @@ private:
 
     // Now a per profile option this one represents the state of this profile:
     bool mCompactInputLine;
+    bool mUnderlineHyperlinks = true;
 
     QTimer purgeTimer;
 

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -953,12 +953,16 @@ COMMIT_LINE:
 
         if (mHyperlinkActive) {
             c.mLinkIndex = mCurrentHyperlinkLinkId;
-            c.mFlags |= TChar::Underline;
+            if (mpHost->getUnderlineHyperlinks()) {
+                c.mFlags |= TChar::Underline;
+            }
         }
 
         if (mpHost->mMxpClient.isInLinkMode()) {
             c.mLinkIndex = mLinkStore.getCurrentLinkID();
-            c.mFlags |= TChar::Underline;
+            if (mpHost->getUnderlineHyperlinks()) {
+                c.mFlags |= TChar::Underline;
+            }
         }
 
         if (mpHost->mMxpClient.hasFgColor()) {

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1591,6 +1591,15 @@ int TLuaInterpreter::getMudletHomeDir(lua_State* L)
     return 1;
 }
 
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#enableHyperlinkUnderline
+int TLuaInterpreter::enableHyperlinkUnderline(lua_State* L)
+{
+    const bool enabled = getVerifiedBool(L, __func__, 1, "enabled");
+    Host& host = getHostFromLua(L);
+    host.setUnderlineHyperlinks(enabled);
+    return 0;
+}
+
 // No documentation available in wiki - internal function used by printError in DebugTools.lua
 int TLuaInterpreter::errorc(lua_State* L)
 {
@@ -5242,6 +5251,7 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "disableHorizontalScrollBar", TLuaInterpreter::disableHorizontalScrollBar);
     lua_register(pGlobalLua, "enableCommandLine", TLuaInterpreter::enableCommandLine);
     lua_register(pGlobalLua, "disableCommandLine", TLuaInterpreter::disableCommandLine);
+    lua_register(pGlobalLua, "enableHyperlinkUnderline", TLuaInterpreter::enableHyperlinkUnderline);
     lua_register(pGlobalLua, "startLogging", TLuaInterpreter::startLogging);
     lua_register(pGlobalLua, "appendLog", TLuaInterpreter::appendLog);
     lua_register(pGlobalLua, "calcFontSize", TLuaInterpreter::calcFontSize);
@@ -7480,6 +7490,11 @@ int TLuaInterpreter::setConfig(lua_State * L)
         host.setCommandLineHistorySaveSize(value);
         return success();
     }
+    if (key == qsl("underlineHyperlinks")) {
+        const bool value = getVerifiedBool(L, __func__, 2, "value");
+        host.setUnderlineHyperlinks(value);
+        return success();
+    }
     if (key == qsl("controlCharacterHandling")) {
         static const QStringList values{"asis", "oem", "picture"};
         const auto value = getVerifiedString(L, __func__, 2, "value");
@@ -7624,6 +7639,7 @@ int TLuaInterpreter::getConfig(lua_State *L)
             }
         } },
         { qsl("commandLineHistorySaveSize"), [&](){ lua_pushnumber(L, host.getCommandLineHistorySaveSize()); } },
+        { qsl("underlineHyperlinks"), [&](){ lua_pushboolean(L, host.getUnderlineHyperlinks()); } },
         { qsl("controlCharacterHandling"), [&](){
             const auto controlCharacterMode = host.getControlCharacterMode();
             switch (controlCharacterMode) {

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -497,6 +497,7 @@ public:
     static int scrollingActive(lua_State*);
     static int enableCommandLine(lua_State*);
     static int disableCommandLine(lua_State*);
+    static int enableHyperlinkUnderline(lua_State*);
     static int enableClickthrough(lua_State*);
     static int disableClickthrough(lua_State*);
     static int startLogging(lua_State*);

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -473,6 +473,7 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
     host.append_attribute("playerRoomInnerDiameter") = QString::number(innerDiameterPercentage).toUtf8().constData();
     host.append_attribute("CompactInputLine") = pHost->getCompactInputLine() ? "yes" : "no";
     host.append_attribute("CommandLineHistorySaveSize") = QString::number(pHost->getCommandLineHistorySaveSize()).toUtf8().constData();
+    host.append_attribute("underlineHyperlinks") = pHost->getUnderlineHyperlinks() ? "yes" : "no";
 
     QString ignore;
     QSetIterator<QChar> ignoreIterator(pHost->mDoubleClickIgnore);

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -973,6 +973,13 @@ void XMLimport::readHost(Host* pHost)
         pHost->setCommandLineHistorySaveSize(500);
     }
 
+    if (attributes().hasAttribute(QLatin1String("underlineHyperlinks"))) {
+        pHost->setUnderlineHyperlinks(attributes().value(QLatin1String("underlineHyperlinks")) == YES);
+    } else {
+        // Default behaviour before this setting was introduced
+        pHost->setUnderlineHyperlinks(true);
+    }
+
     if (attributes().hasAttribute(QLatin1String("NetworkPacketTimeout"))) {
         // These limits are also hard coded into the QSpinBox used to adjust
         // this setting in the preferences:

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -384,6 +384,7 @@ void dlgProfilePreferences::disableHostDetails()
 
     // ----- groupBox_miscellaneous -----
     mAlertOnNewData->setEnabled(false);
+    checkBox_underlineHyperlinks->setEnabled(false);
     acceptServerGUI->setEnabled(false);
     mFORCE_SAVE_ON_EXIT->setEnabled(false);
     acceptServerMedia->setEnabled(false);
@@ -517,6 +518,7 @@ void dlgProfilePreferences::enableHostDetails()
 
     // ----- groupBox_miscellaneous -----
     mAlertOnNewData->setEnabled(true);
+    checkBox_underlineHyperlinks->setEnabled(true);
     acceptServerGUI->setEnabled(true);
     mFORCE_SAVE_ON_EXIT->setEnabled(true);
     acceptServerMedia->setEnabled(true);
@@ -866,6 +868,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     mFORCE_MCCP_OFF->setChecked(pHost->mFORCE_NO_COMPRESSION);
     mFORCE_GA_OFF->setChecked(pHost->mFORCE_GA_OFF);
     mAlertOnNewData->setChecked(pHost->mAlertOnNewData);
+    checkBox_underlineHyperlinks->setChecked(pHost->getUnderlineHyperlinks());
     //encoding->setCurrentIndex( pHost->mEncoding );
     mFORCE_SAVE_ON_EXIT->setChecked(pHost->mFORCE_SAVE_ON_EXIT);
 
@@ -1250,6 +1253,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     connect(mIsToLogInHtml, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_changeLogFileAsHtml);
     connect(doubleSpinBox_networkPacketTimeout, qOverload<double>(&QDoubleSpinBox::valueChanged), this, &dlgProfilePreferences::slot_setPostingTimeout);
     connect(checkBox_largeAreaExitArrows, &QCheckBox::toggled, this, &dlgProfilePreferences::slot_changeLargeAreaExitArrows);
+    connect(checkBox_underlineHyperlinks, &QCheckBox::toggled, this, &dlgProfilePreferences::slot_changeUnderlineHyperlinks);
 
     //Shortcuts tab
     auto shortcutKeys = mudlet::self()->mpShortcutsManager->iterator();
@@ -1375,6 +1379,7 @@ void dlgProfilePreferences::disconnectHostRelatedControls()
     disconnect(spinBox_playerRoomOuterDiameter, qOverload<int>(&QSpinBox::valueChanged), nullptr, nullptr);
     disconnect(spinBox_playerRoomInnerDiameter, qOverload<int>(&QSpinBox::valueChanged), nullptr, nullptr);
     disconnect(checkBox_largeAreaExitArrows, &QCheckBox::toggled, nullptr, nullptr);
+    disconnect(checkBox_underlineHyperlinks, &QCheckBox::toggled, nullptr, nullptr);
 }
 
 void dlgProfilePreferences::clearHostDetails()
@@ -1435,6 +1440,7 @@ void dlgProfilePreferences::clearHostDetails()
     mFORCE_MCCP_OFF->setChecked(false);
     mFORCE_GA_OFF->setChecked(false);
     mAlertOnNewData->setChecked(false);
+    checkBox_underlineHyperlinks->setChecked(true);
     mFORCE_SAVE_ON_EXIT->setChecked(false);
 
     pushButton_chooseProfiles->setEnabled(false);
@@ -2955,6 +2961,7 @@ void dlgProfilePreferences::slot_saveAndClose()
         pHost->mLogFileNameFormat = comboBox_logFileNameFormat->currentData().toString();
         pHost->mNoAntiAlias = !mNoAntiAlias->isChecked();
         pHost->mAlertOnNewData = mAlertOnNewData->isChecked();
+        pHost->setUnderlineHyperlinks(checkBox_underlineHyperlinks->isChecked());
 
         pHost->mUseProxy = groupBox_proxy->isChecked();
         pHost->mProxyAddress = lineEdit_proxyAddress->text();
@@ -4566,4 +4573,14 @@ void dlgProfilePreferences::slot_changeLargeAreaExitArrows(const bool state)
     }
 
     pHost->setLargeAreaExitArrows(state);
+}
+
+void dlgProfilePreferences::slot_changeUnderlineHyperlinks(const bool state)
+{
+    Host* pHost = mpHost;
+    if (!pHost) {
+        return;
+    }
+
+    pHost->setUnderlineHyperlinks(state);
 }

--- a/src/dlgProfilePreferences.h
+++ b/src/dlgProfilePreferences.h
@@ -174,6 +174,7 @@ private slots:
     void slot_changeWrapAt();
     void slot_deleteMap();
     void slot_changeLargeAreaExitArrows(const bool);
+    void slot_changeUnderlineHyperlinks(const bool);
     void slot_hidePasswordMigrationLabel();
     void slot_loadHistoryMap();
 

--- a/src/lua-function-list.json
+++ b/src/lua-function-list.json
@@ -124,6 +124,7 @@
     "enableAlias": "enableAlias(name)",
     "enableClickthrough": "enableClickthrough(label)",
     "enableCommandLine": "enableCommandLine(windowName)",
+    "enableHyperlinkUnderline": "enableHyperlinkUnderline(enabled)",
     "enableHorizontalScrollBar": "enableHorizontalScrollBar([windowName])",
     "enableKey": "enableKey(name)",
     "enableMapInfo": "enableMapInfo(label)",

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -296,8 +296,18 @@
             </property>
            </widget>
           </item>
-         </layout>
-        </widget>
+          <item row="3" column="0" colspan="2">
+           <widget class="QCheckBox" name="checkBox_underlineHyperlinks">
+            <property name="text">
+             <string>Underline hyperlinks in the main display</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+        </layout>
+       </widget>
        </item>
        <item>
         <widget class="QGroupBox" name="groupBox_protocols">


### PR DESCRIPTION
## Summary
- allow disabling hyperlink underlining via Host property
- gate underline rendering in `TBuffer`
- expose Lua API `enableHyperlinkUnderline`
- add optional preference checkbox
- document new Lua function
- persist preference in profile XML

## Testing
- `ctest --output-on-failure -j4` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_68697ad5e630832b859ce12219c86ed6