### PR TITLE
Add MXP hyperlink style option

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -3090,9 +3090,9 @@ void Host::setCompactInputLine(const bool state)
     }
 }
 
-void Host::setUnderlineHyperlinks(bool state)
+void Host::setHyperlinkStyle(HyperlinkStyle style)
 {
-    mUnderlineHyperlinks = state;
+    mHyperlinkStyle = style;
 }
 
 QPointer<TConsole> Host::findConsole(QString name)

--- a/src/Host.h
+++ b/src/Host.h
@@ -214,8 +214,20 @@ public:
     ControlCharacterMode  getControlCharacterMode() const { return mControlCharacter; }
     bool            getLargeAreaExitArrows() const { return mLargeAreaExitArrows; }
     void            setLargeAreaExitArrows(const bool);
-    bool            getUnderlineHyperlinks() const { return mUnderlineHyperlinks; }
-    void            setUnderlineHyperlinks(bool);
+    enum class HyperlinkStyle {
+        None,
+        Underline,
+        Bold,
+        Italic
+    };
+    Q_ENUM(HyperlinkStyle)
+
+    HyperlinkStyle  getHyperlinkStyle() const { return mHyperlinkStyle; }
+    void            setHyperlinkStyle(HyperlinkStyle style);
+
+    // compatibility wrappers
+    bool            getUnderlineHyperlinks() const { return mHyperlinkStyle == HyperlinkStyle::Underline; }
+    void            setUnderlineHyperlinks(bool state) { mHyperlinkStyle = state ? HyperlinkStyle::Underline : HyperlinkStyle::None; }
 
     void            forceClose();
     bool            isClosingDown() const { return mIsClosingDown; }
@@ -906,7 +918,7 @@ private:
 
     // Now a per profile option this one represents the state of this profile:
     bool mCompactInputLine;
-    bool mUnderlineHyperlinks = true;
+    HyperlinkStyle mHyperlinkStyle = HyperlinkStyle::Underline;
 
     QTimer purgeTimer;
 

--- a/src/TBuffer.cpp
+++ b/src/TBuffer.cpp
@@ -22,6 +22,7 @@
 
 
 #include "TBuffer.h"
+#include "Host.h"
 
 #include "mudlet.h"
 #include "TEvent.h"
@@ -953,15 +954,35 @@ COMMIT_LINE:
 
         if (mHyperlinkActive) {
             c.mLinkIndex = mCurrentHyperlinkLinkId;
-            if (mpHost->getUnderlineHyperlinks()) {
+            switch (mpHost->getHyperlinkStyle()) {
+            case Host::HyperlinkStyle::Underline:
                 c.mFlags |= TChar::Underline;
+                break;
+            case Host::HyperlinkStyle::Bold:
+                c.mFlags |= TChar::Bold;
+                break;
+            case Host::HyperlinkStyle::Italic:
+                c.mFlags |= TChar::Italic;
+                break;
+            default:
+                break;
             }
         }
 
         if (mpHost->mMxpClient.isInLinkMode()) {
             c.mLinkIndex = mLinkStore.getCurrentLinkID();
-            if (mpHost->getUnderlineHyperlinks()) {
+            switch (mpHost->getHyperlinkStyle()) {
+            case Host::HyperlinkStyle::Underline:
                 c.mFlags |= TChar::Underline;
+                break;
+            case Host::HyperlinkStyle::Bold:
+                c.mFlags |= TChar::Bold;
+                break;
+            case Host::HyperlinkStyle::Italic:
+                c.mFlags |= TChar::Italic;
+                break;
+            default:
+                break;
             }
         }
 

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -7490,6 +7490,21 @@ int TLuaInterpreter::setConfig(lua_State * L)
         host.setCommandLineHistorySaveSize(value);
         return success();
     }
+    if (key == qsl("hyperlinkStyle")) {
+        const auto value = getVerifiedString(L, __func__, 2, "value").toLower();
+        if (value == qsl("none")) {
+            host.setHyperlinkStyle(Host::HyperlinkStyle::None);
+        } else if (value == qsl("underline")) {
+            host.setHyperlinkStyle(Host::HyperlinkStyle::Underline);
+        } else if (value == qsl("bold")) {
+            host.setHyperlinkStyle(Host::HyperlinkStyle::Bold);
+        } else if (value == qsl("italic")) {
+            host.setHyperlinkStyle(Host::HyperlinkStyle::Italic);
+        } else {
+            return failure("Invalid hyperlinkStyle value");
+        }
+        return success();
+    }
     if (key == qsl("underlineHyperlinks")) {
         const bool value = getVerifiedBool(L, __func__, 2, "value");
         host.setUnderlineHyperlinks(value);
@@ -7639,6 +7654,22 @@ int TLuaInterpreter::getConfig(lua_State *L)
             }
         } },
         { qsl("commandLineHistorySaveSize"), [&](){ lua_pushnumber(L, host.getCommandLineHistorySaveSize()); } },
+        { qsl("hyperlinkStyle"), [&](){
+            switch (host.getHyperlinkStyle()) {
+            case Host::HyperlinkStyle::None:
+                lua_pushstring(L, "none");
+                break;
+            case Host::HyperlinkStyle::Underline:
+                lua_pushstring(L, "underline");
+                break;
+            case Host::HyperlinkStyle::Bold:
+                lua_pushstring(L, "bold");
+                break;
+            case Host::HyperlinkStyle::Italic:
+                lua_pushstring(L, "italic");
+                break;
+            }
+        } },
         { qsl("underlineHyperlinks"), [&](){ lua_pushboolean(L, host.getUnderlineHyperlinks()); } },
         { qsl("controlCharacterHandling"), [&](){
             const auto controlCharacterMode = host.getControlCharacterMode();

--- a/src/XMLexport.cpp
+++ b/src/XMLexport.cpp
@@ -38,6 +38,7 @@
 
 #include "pre_guard.h"
 #include <QtConcurrent>
+#include <QMetaEnum>
 #include <QFile>
 #include <sstream>
 #include "post_guard.h"
@@ -473,7 +474,8 @@ void XMLexport::writeHost(Host* pHost, pugi::xml_node mudletPackage)
     host.append_attribute("playerRoomInnerDiameter") = QString::number(innerDiameterPercentage).toUtf8().constData();
     host.append_attribute("CompactInputLine") = pHost->getCompactInputLine() ? "yes" : "no";
     host.append_attribute("CommandLineHistorySaveSize") = QString::number(pHost->getCommandLineHistorySaveSize()).toUtf8().constData();
-    host.append_attribute("underlineHyperlinks") = pHost->getUnderlineHyperlinks() ? "yes" : "no";
+    host.append_attribute("hyperlinkStyle") = QMetaEnum::fromType<Host::HyperlinkStyle>().valueToKey(
+            static_cast<int>(pHost->getHyperlinkStyle()));
 
     QString ignore;
     QSetIterator<QChar> ignoreIterator(pHost->mDoubleClickIgnore);

--- a/src/XMLimport.cpp
+++ b/src/XMLimport.cpp
@@ -35,6 +35,7 @@
 #include "pre_guard.h"
 #include <QBuffer>
 #include <QtMath>
+#include <QMetaEnum>
 #include "post_guard.h"
 
 XMLimport::XMLimport(Host* pH)
@@ -973,11 +974,21 @@ void XMLimport::readHost(Host* pHost)
         pHost->setCommandLineHistorySaveSize(500);
     }
 
-    if (attributes().hasAttribute(QLatin1String("underlineHyperlinks"))) {
+    if (attributes().hasAttribute(QLatin1String("hyperlinkStyle"))) {
+        const QStringView style(attributes().value(qsl("hyperlinkStyle")));
+        if (style == qsl("None")) {
+            pHost->setHyperlinkStyle(Host::HyperlinkStyle::None);
+        } else if (style == qsl("Underline")) {
+            pHost->setHyperlinkStyle(Host::HyperlinkStyle::Underline);
+        } else if (style == qsl("Bold")) {
+            pHost->setHyperlinkStyle(Host::HyperlinkStyle::Bold);
+        } else if (style == qsl("Italic")) {
+            pHost->setHyperlinkStyle(Host::HyperlinkStyle::Italic);
+        }
+    } else if (attributes().hasAttribute(QLatin1String("underlineHyperlinks"))) {
         pHost->setUnderlineHyperlinks(attributes().value(QLatin1String("underlineHyperlinks")) == YES);
     } else {
-        // Default behaviour before this setting was introduced
-        pHost->setUnderlineHyperlinks(true);
+        pHost->setHyperlinkStyle(Host::HyperlinkStyle::Underline);
     }
 
     if (attributes().hasAttribute(QLatin1String("NetworkPacketTimeout"))) {

--- a/src/dlgProfilePreferences.cpp
+++ b/src/dlgProfilePreferences.cpp
@@ -384,7 +384,7 @@ void dlgProfilePreferences::disableHostDetails()
 
     // ----- groupBox_miscellaneous -----
     mAlertOnNewData->setEnabled(false);
-    checkBox_underlineHyperlinks->setEnabled(false);
+    comboBox_hyperlinkStyle->setEnabled(false);
     acceptServerGUI->setEnabled(false);
     mFORCE_SAVE_ON_EXIT->setEnabled(false);
     acceptServerMedia->setEnabled(false);
@@ -518,7 +518,7 @@ void dlgProfilePreferences::enableHostDetails()
 
     // ----- groupBox_miscellaneous -----
     mAlertOnNewData->setEnabled(true);
-    checkBox_underlineHyperlinks->setEnabled(true);
+    comboBox_hyperlinkStyle->setEnabled(true);
     acceptServerGUI->setEnabled(true);
     mFORCE_SAVE_ON_EXIT->setEnabled(true);
     acceptServerMedia->setEnabled(true);
@@ -868,7 +868,20 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     mFORCE_MCCP_OFF->setChecked(pHost->mFORCE_NO_COMPRESSION);
     mFORCE_GA_OFF->setChecked(pHost->mFORCE_GA_OFF);
     mAlertOnNewData->setChecked(pHost->mAlertOnNewData);
-    checkBox_underlineHyperlinks->setChecked(pHost->getUnderlineHyperlinks());
+    switch (pHost->getHyperlinkStyle()) {
+    case Host::HyperlinkStyle::None:
+        comboBox_hyperlinkStyle->setCurrentIndex(0);
+        break;
+    case Host::HyperlinkStyle::Underline:
+        comboBox_hyperlinkStyle->setCurrentIndex(1);
+        break;
+    case Host::HyperlinkStyle::Bold:
+        comboBox_hyperlinkStyle->setCurrentIndex(2);
+        break;
+    case Host::HyperlinkStyle::Italic:
+        comboBox_hyperlinkStyle->setCurrentIndex(3);
+        break;
+    }
     //encoding->setCurrentIndex( pHost->mEncoding );
     mFORCE_SAVE_ON_EXIT->setChecked(pHost->mFORCE_SAVE_ON_EXIT);
 
@@ -1253,7 +1266,7 @@ void dlgProfilePreferences::initWithHost(Host* pHost)
     connect(mIsToLogInHtml, &QAbstractButton::clicked, this, &dlgProfilePreferences::slot_changeLogFileAsHtml);
     connect(doubleSpinBox_networkPacketTimeout, qOverload<double>(&QDoubleSpinBox::valueChanged), this, &dlgProfilePreferences::slot_setPostingTimeout);
     connect(checkBox_largeAreaExitArrows, &QCheckBox::toggled, this, &dlgProfilePreferences::slot_changeLargeAreaExitArrows);
-    connect(checkBox_underlineHyperlinks, &QCheckBox::toggled, this, &dlgProfilePreferences::slot_changeUnderlineHyperlinks);
+    connect(comboBox_hyperlinkStyle, qOverload<int>(&QComboBox::currentIndexChanged), this, &dlgProfilePreferences::slot_changeHyperlinkStyle);
 
     //Shortcuts tab
     auto shortcutKeys = mudlet::self()->mpShortcutsManager->iterator();
@@ -1379,7 +1392,7 @@ void dlgProfilePreferences::disconnectHostRelatedControls()
     disconnect(spinBox_playerRoomOuterDiameter, qOverload<int>(&QSpinBox::valueChanged), nullptr, nullptr);
     disconnect(spinBox_playerRoomInnerDiameter, qOverload<int>(&QSpinBox::valueChanged), nullptr, nullptr);
     disconnect(checkBox_largeAreaExitArrows, &QCheckBox::toggled, nullptr, nullptr);
-    disconnect(checkBox_underlineHyperlinks, &QCheckBox::toggled, nullptr, nullptr);
+    disconnect(comboBox_hyperlinkStyle, &QComboBox::currentIndexChanged, nullptr, nullptr);
 }
 
 void dlgProfilePreferences::clearHostDetails()
@@ -1440,7 +1453,7 @@ void dlgProfilePreferences::clearHostDetails()
     mFORCE_MCCP_OFF->setChecked(false);
     mFORCE_GA_OFF->setChecked(false);
     mAlertOnNewData->setChecked(false);
-    checkBox_underlineHyperlinks->setChecked(true);
+    comboBox_hyperlinkStyle->setCurrentIndex(1);
     mFORCE_SAVE_ON_EXIT->setChecked(false);
 
     pushButton_chooseProfiles->setEnabled(false);
@@ -2961,7 +2974,7 @@ void dlgProfilePreferences::slot_saveAndClose()
         pHost->mLogFileNameFormat = comboBox_logFileNameFormat->currentData().toString();
         pHost->mNoAntiAlias = !mNoAntiAlias->isChecked();
         pHost->mAlertOnNewData = mAlertOnNewData->isChecked();
-        pHost->setUnderlineHyperlinks(checkBox_underlineHyperlinks->isChecked());
+        pHost->setHyperlinkStyle(static_cast<Host::HyperlinkStyle>(comboBox_hyperlinkStyle->currentIndex()));
 
         pHost->mUseProxy = groupBox_proxy->isChecked();
         pHost->mProxyAddress = lineEdit_proxyAddress->text();
@@ -4575,12 +4588,12 @@ void dlgProfilePreferences::slot_changeLargeAreaExitArrows(const bool state)
     pHost->setLargeAreaExitArrows(state);
 }
 
-void dlgProfilePreferences::slot_changeUnderlineHyperlinks(const bool state)
+void dlgProfilePreferences::slot_changeHyperlinkStyle(const int index)
 {
     Host* pHost = mpHost;
     if (!pHost) {
         return;
     }
 
-    pHost->setUnderlineHyperlinks(state);
+    pHost->setHyperlinkStyle(static_cast<Host::HyperlinkStyle>(index));
 }

--- a/src/dlgProfilePreferences.h
+++ b/src/dlgProfilePreferences.h
@@ -174,7 +174,7 @@ private slots:
     void slot_changeWrapAt();
     void slot_deleteMap();
     void slot_changeLargeAreaExitArrows(const bool);
-    void slot_changeUnderlineHyperlinks(const bool);
+    void slot_changeHyperlinkStyle(const int);
     void slot_hidePasswordMigrationLabel();
     void slot_loadHistoryMap();
 

--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -297,13 +297,27 @@
            </widget>
           </item>
           <item row="3" column="0" colspan="2">
-           <widget class="QCheckBox" name="checkBox_underlineHyperlinks">
-            <property name="text">
-             <string>Underline hyperlinks in the main display</string>
-            </property>
-            <property name="checked">
-             <bool>true</bool>
-            </property>
+           <widget class="QComboBox" name="comboBox_hyperlinkStyle">
+            <item>
+             <property name="text">
+              <string>None</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Underline</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Bold</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Italic</string>
+             </property>
+            </item>
            </widget>
           </item>
         </layout>


### PR DESCRIPTION
## Summary
- allow choosing MXP hyperlink style (none, underline, bold, italic)
- persist hyperlink style in profile XML
- expose hyperlink style option to Lua
- add combo box for hyperlink style in preferences
- render hyperlinks with selected attribute

## Testing
- `cmake -B build -S .` *(fails: Could NOT find XKB)*
- `cmake --build build -j$(nproc)` *(fails: translation-stats.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_686a7eeed304832bb81e1c38de88f4ae