### PR TITLE
Add Lua functions for hyperlink style

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -1600,6 +1600,89 @@ int TLuaInterpreter::enableHyperlinkUnderline(lua_State* L)
     return 0;
 }
 
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setHyperlinkStyle
+int TLuaInterpreter::setHyperlinkStyle(lua_State* L)
+{
+    static const QStringList styles{"none", "underline", "bold", "italic"};
+    const QString style = getVerifiedString(L, __func__, 1, "style").toLower();
+    if (!styles.contains(style)) {
+        return warnArgumentValue(L, __func__,
+                                 qsl("invalid hyperlink style '%1', expected one of '%2'")
+                                     .arg(style, styles.join(qsl("\", \""))));
+    }
+
+    Host& host = getHostFromLua(L);
+    if (style == qsl("none")) {
+        host.setHyperlinkStyle(Host::HyperlinkStyle::None);
+    } else if (style == qsl("underline")) {
+        host.setHyperlinkStyle(Host::HyperlinkStyle::Underline);
+    } else if (style == qsl("bold")) {
+        host.setHyperlinkStyle(Host::HyperlinkStyle::Bold);
+    } else if (style == qsl("italic")) {
+        host.setHyperlinkStyle(Host::HyperlinkStyle::Italic);
+    }
+
+    return 0;
+}
+
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getHyperlinkStyle
+int TLuaInterpreter::getHyperlinkStyle(lua_State* L)
+{
+    const Host& host = getHostFromLua(L);
+    switch (host.getHyperlinkStyle()) {
+    case Host::HyperlinkStyle::None:
+        lua_pushstring(L, "none");
+        break;
+    case Host::HyperlinkStyle::Underline:
+        lua_pushstring(L, "underline");
+        break;
+    case Host::HyperlinkStyle::Bold:
+        lua_pushstring(L, "bold");
+        break;
+    case Host::HyperlinkStyle::Italic:
+        lua_pushstring(L, "italic");
+        break;
+    }
+    return 1;
+}
+
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setHyperlinkStyleColor
+int TLuaInterpreter::setHyperlinkStyleColor(lua_State* L)
+{
+    auto validRange = [](int number) { return number >= 0 && number <= 255; };
+
+    const int r = getVerifiedInt(L, __func__, 1, "red value");
+    if (!validRange(r)) {
+        return warnArgumentValue(L, __func__, csmInvalidRedValue.arg(r));
+    }
+
+    const int g = getVerifiedInt(L, __func__, 2, "green value");
+    if (!validRange(g)) {
+        return warnArgumentValue(L, __func__, csmInvalidGreenValue.arg(g));
+    }
+
+    const int b = getVerifiedInt(L, __func__, 3, "blue value");
+    if (!validRange(b)) {
+        return warnArgumentValue(L, __func__, csmInvalidBlueValue.arg(b));
+    }
+
+    Host& host = getHostFromLua(L);
+    host.mHyperlinkFgColor = QColor(r, g, b);
+
+    return 0;
+}
+
+// Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#getHyperlinkStyleColor
+int TLuaInterpreter::getHyperlinkStyleColor(lua_State* L)
+{
+    const Host& host = getHostFromLua(L);
+    const QColor c = host.mHyperlinkFgColor;
+    lua_pushnumber(L, c.red());
+    lua_pushnumber(L, c.green());
+    lua_pushnumber(L, c.blue());
+    return 3;
+}
+
 // No documentation available in wiki - internal function used by printError in DebugTools.lua
 int TLuaInterpreter::errorc(lua_State* L)
 {
@@ -5252,6 +5335,10 @@ void TLuaInterpreter::initLuaGlobals()
     lua_register(pGlobalLua, "enableCommandLine", TLuaInterpreter::enableCommandLine);
     lua_register(pGlobalLua, "disableCommandLine", TLuaInterpreter::disableCommandLine);
     lua_register(pGlobalLua, "enableHyperlinkUnderline", TLuaInterpreter::enableHyperlinkUnderline);
+    lua_register(pGlobalLua, "setHyperlinkStyle", TLuaInterpreter::setHyperlinkStyle);
+    lua_register(pGlobalLua, "getHyperlinkStyle", TLuaInterpreter::getHyperlinkStyle);
+    lua_register(pGlobalLua, "setHyperlinkStyleColor", TLuaInterpreter::setHyperlinkStyleColor);
+    lua_register(pGlobalLua, "getHyperlinkStyleColor", TLuaInterpreter::getHyperlinkStyleColor);
     lua_register(pGlobalLua, "startLogging", TLuaInterpreter::startLogging);
     lua_register(pGlobalLua, "appendLog", TLuaInterpreter::appendLog);
     lua_register(pGlobalLua, "calcFontSize", TLuaInterpreter::calcFontSize);

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -498,6 +498,10 @@ public:
     static int enableCommandLine(lua_State*);
     static int disableCommandLine(lua_State*);
     static int enableHyperlinkUnderline(lua_State*);
+    static int setHyperlinkStyle(lua_State*);
+    static int getHyperlinkStyle(lua_State*);
+    static int setHyperlinkStyleColor(lua_State*);
+    static int getHyperlinkStyleColor(lua_State*);
     static int enableClickthrough(lua_State*);
     static int disableClickthrough(lua_State*);
     static int startLogging(lua_State*);


### PR DESCRIPTION
## Summary
- provide Lua APIs `setHyperlinkStyle`, `getHyperlinkStyle`, `setHyperlinkStyleColor`, and `getHyperlinkStyleColor`
- register the new functions in Lua interface

## Testing
- `cmake -S test -B test/build` *(fails: Could not find a package configuration file provided by "Qt6")*

------
https://chatgpt.com/codex/tasks/task_e_686ae7899090832b97d03ed9824cebc5