### PR TITLE
Extend MXP send event with caption

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3527,7 +3527,7 @@ void TLuaInterpreter::setAtcpTable(const QString& var, const QString& arg)
 }
 
 // No documentation available in wiki - internal function
-void TLuaInterpreter::signalMXPEvent(const QString &type, const QMap<QString, QString> &attrs, const QStringList &actions)
+void TLuaInterpreter::signalMXPEvent(const QString &type, const QMap<QString, QString> &attrs, const QStringList &actions, const QString &caption)
 {
     lua_State *L = pGlobalLua;
     lua_getglobal(L, "mxp");
@@ -3563,6 +3563,9 @@ void TLuaInterpreter::signalMXPEvent(const QString &type, const QMap<QString, QS
         lua_pushstring(L, actions[i].toUtf8().constData());
         lua_rawseti(L, -2, i + 1);
     }
+
+    lua_pushstring(L, caption.toUtf8().constData());
+    lua_setfield(L, -2, "caption");
 
     lua_pop(L, lua_gettop(L));
 

--- a/src/TLuaInterpreter.h
+++ b/src/TLuaInterpreter.h
@@ -112,7 +112,7 @@ public:
     double condenseMapLoad();
     bool compile(const QString& code, QString& error, const QString& name);
     void setAtcpTable(const QString&, const QString&);
-    void signalMXPEvent(const QString& type, const QMap<QString, QString>& attrs, const QStringList& actions);
+    void signalMXPEvent(const QString& type, const QMap<QString, QString>& attrs, const QStringList& actions, const QString& caption = QString());
     void setGMCPTable(QString&, const QString&);
     void setMSSPTable(const QString&);
     void setChannel102Table(int& var, int& arg);

--- a/src/TMainConsole.cpp
+++ b/src/TMainConsole.cpp
@@ -1161,7 +1161,7 @@ void TMainConsole::printOnDisplay(std::string& incomingSocketData, const bool is
     auto& mxpEventQueue = mpHost->mMxpClient.mMxpEvents;
     while (!mxpEventQueue.isEmpty()) {
         const auto& event = mxpEventQueue.dequeue();
-        mpHost->mLuaInterpreter.signalMXPEvent(event.name, event.attrs, event.actions);
+        mpHost->mLuaInterpreter.signalMXPEvent(event.name, event.attrs, event.actions, event.caption);
     }
 
     const double processT = mProcessingTimer.elapsed() / 1000.0;

--- a/src/TMxpClient.h
+++ b/src/TMxpClient.h
@@ -99,6 +99,8 @@ public:
         Q_UNUSED(tag)
         return result;
     }
+
+    virtual void setCaptionForSendEvent(const QString& caption) { Q_UNUSED(caption) }
 };
 
 #endif //MUDLET_TMXPCLIENT_H

--- a/src/TMxpEvent.h
+++ b/src/TMxpEvent.h
@@ -30,6 +30,7 @@ struct TMxpEvent
     QString name;
     QMap<QString, QString> attrs;
     QStringList actions;
+    QString caption;
 };
 
 #endif //MUDLET_TMXPEVENT_H

--- a/src/TMxpMudlet.cpp
+++ b/src/TMxpMudlet.cpp
@@ -22,6 +22,7 @@
 #include "TMedia.h"
 #include "TConsole.h"
 #include "TLinkStore.h"
+#include <QStack>
 
 
 QString TMxpMudlet::getVersion()
@@ -93,6 +94,7 @@ TMxpTagHandlerResult TMxpMudlet::tagHandled(MxpTag* tag, TMxpTagHandlerResult re
             enqueueMxpEvent(tag->asStartTag());
         } else if (tag->isNamed("SEND")) {
             enqueueMxpEvent(tag->asStartTag());
+            mSendEventIndices.push(mMxpEvents.size() - 1);
         }
     }
 
@@ -107,7 +109,18 @@ void TMxpMudlet::enqueueMxpEvent(MxpStartTag* tag)
         mxpEvent.attrs[attrName] = tag->getAttributeValue(attrName);
     }
     mxpEvent.actions = getLinkStore().getCurrentLinks();
+    mxpEvent.caption.clear();
     mMxpEvents.enqueue(mxpEvent);
+}
+
+void TMxpMudlet::setCaptionForSendEvent(const QString& caption)
+{
+    if (!mSendEventIndices.isEmpty()) {
+        int idx = mSendEventIndices.pop();
+        if (idx >= 0 && idx < mMxpEvents.size()) {
+            mMxpEvents[idx].caption = caption;
+        }
+    }
 }
 
 TLinkStore& TMxpMudlet::getLinkStore()

--- a/src/TMxpMudlet.h
+++ b/src/TMxpMudlet.h
@@ -129,6 +129,10 @@ public:
     // Shouldn't be here, look for a better solution
     QQueue<TMxpEvent> mMxpEvents;
 
+    void setCaptionForSendEvent(const QString& caption) override;
+
+    QStack<int> mSendEventIndices;
+
 private:
     Host* mpHost;
     bool mLinkMode;

--- a/src/TMxpSendTagHandler.cpp
+++ b/src/TMxpSendTagHandler.cpp
@@ -26,6 +26,8 @@ TMxpTagHandlerResult TMxpSendTagHandler::handleStartTag(TMxpContext& ctx, TMxpCl
     //    if (tag->hasAttr("EXPIRE") && tag->getAttr(0).isNamed("EXPIRE"))
     //        return MXP_TAG_NOT_HANDLED;
 
+    mLastCaption.clear();
+
     QString href = extractHref(tag);
     QString hint = extractHint(tag);
 
@@ -115,6 +117,9 @@ TMxpTagHandlerResult TMxpSendTagHandler::handleEndTag(TMxpContext& ctx, TMxpClie
     if (mIsHrefInContent) {
         updateHrefInLinks(client);
     }
+
+    mLastCaption = mCurrentTagContent;
+    client.setCaptionForSendEvent(mLastCaption);
 
     resetCurrentTagContent(client);
     return MXP_TAG_HANDLED;

--- a/src/TMxpSendTagHandler.h
+++ b/src/TMxpSendTagHandler.h
@@ -37,10 +37,12 @@ public:
     , mLinkId(0)
     {}
 
-    TMxpTagHandlerResult handleStartTag(TMxpContext& ctx, TMxpClient& client, MxpStartTag* tag) override;
-    TMxpTagHandlerResult handleEndTag(TMxpContext& ctx, TMxpClient& client, MxpEndTag* tag) override;
+      TMxpTagHandlerResult handleStartTag(TMxpContext& ctx, TMxpClient& client, MxpStartTag* tag) override;
+      TMxpTagHandlerResult handleEndTag(TMxpContext& ctx, TMxpClient& client, MxpEndTag* tag) override;
 
-    void handleContent(char ch) override;
+      void handleContent(char ch) override;
+
+      QString currentCaption() const { return mLastCaption; }
 
 private:
     void updateHrefInLinks(TMxpClient& client) const;
@@ -54,6 +56,7 @@ private:
 
     bool mIsHrefInContent;
     QString mCurrentTagContent;
+    QString mLastCaption;
     int mLinkId;
 };
 

--- a/src/mudlet-lua/README.md
+++ b/src/mudlet-lua/README.md
@@ -18,3 +18,8 @@ Project structure:
         TODO
 
 Current unit tests status: [![Build Status](https://travis-ci.org/vadi2/mudlet-lua.png?branch=master)](https://travis-ci.org/vadi2/mudlet-lua)
+
+MXP events
+----------
+
+`mxp.send` events now include a `caption` field with the text between the SEND tags.

--- a/test/TMxpSendTagHandlerTest.cpp
+++ b/test/TMxpSendTagHandlerTest.cpp
@@ -265,6 +265,22 @@ private slots:
         QCOMPARE(stub.mHints[1], "BUY SUSPENDERS30901");
     }
 
+    void testCaptionStored() {
+        TMxpStubContext ctx;
+        TMxpStubClient stub;
+
+        auto startTag = parseNode("<SEND href=\"look\">");
+        auto endTag = parseNode("</SEND>");
+
+        TMxpSendTagHandler handler;
+        TMxpTagHandler& tagHandler = handler;
+        tagHandler.handleTag(ctx, stub, startTag->asStartTag());
+        tagHandler.handleContent("room");
+        tagHandler.handleTag(ctx, stub, endTag->asEndTag());
+
+        QCOMPARE(handler.currentCaption(), "room");
+    }
+
 };
 
 #include "TMxpSendTagHandlerTest.moc"


### PR DESCRIPTION
## Summary
- extend `TMxpEvent` with a `caption` field
- capture the caption text in `TMxpSendTagHandler`
- queue the caption for send events via `TMxpMudlet`
- expose caption to Lua with `signalMXPEvent`
- document new field in Lua docs
- test caption capture in `TMxpSendTagHandler`

## Testing
- `cmake ..` *(fails: Could not find Qt6Config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_686aeda41e1c832bb64b691778b085d4