### PR TITLE
Refactor TLuaMXPEventTest

### DIFF
--- a/test/TLuaMXPEventTest.cpp
+++ b/test/TLuaMXPEventTest.cpp
@@ -11,59 +11,73 @@ extern "C" {
 #endif
 }
 
-static void signalMXPEventForTest(lua_State* L, const QString& type,
-                                  const QMap<QString, QString>& attrs,
-                                  const QStringList& actions, const QString& caption)
-{
-    lua_getglobal(L, "mxp");
-    if (!lua_istable(L, -1)) {
-        lua_newtable(L);
-        lua_setglobal(L, "mxp");
+#include "TEvent.h" // needed for completeness
+
+class TLuaInterpreter {
+public:
+    TLuaInterpreter() {
+        L = luaL_newstate();
+        luaL_openlibs(L);
+    }
+    ~TLuaInterpreter() { lua_close(L); }
+
+    lua_State* getLuaGlobalState() { return L; }
+    void signalMXPEvent(const QString& type, const QMap<QString, QString>& attrs,
+                        const QStringList& actions, const QString& caption)
+    {
         lua_getglobal(L, "mxp");
+        if (!lua_istable(L, -1)) {
+            lua_newtable(L);
+            lua_setglobal(L, "mxp");
+            lua_getglobal(L, "mxp");
+            if (!lua_istable(L, -1)) {
+                return;
+            }
+        }
+
+        lua_newtable(L);
+        QByteArray typeLower = type.toUtf8().toLower();
+        lua_setfield(L, -2, typeLower.constData());
+        lua_getfield(L, -1, typeLower.constData());
         if (!lua_istable(L, -1)) {
             return;
         }
+
+        for (auto it = attrs.cbegin(); it != attrs.cend(); ++it) {
+            lua_pushstring(L, it.value().toUtf8().constData());
+            lua_setfield(L, -2, it.key().toUtf8().toLower().constData());
+        }
+
+        lua_newtable(L);
+        lua_setfield(L, -2, "actions");
+        lua_getfield(L, -1, "actions");
+        for (int i = 0; i < actions.size(); ++i) {
+            lua_pushstring(L, actions[i].toUtf8().constData());
+            lua_rawseti(L, -2, i + 1);
+        }
+        lua_pop(L, 1);
+
+        lua_pushstring(L, caption.toUtf8().constData());
+        lua_setfield(L, -2, "caption");
+
+        lua_pop(L, lua_gettop(L));
     }
 
-    lua_newtable(L);
-    QByteArray typeLower = type.toUtf8().toLower();
-    lua_setfield(L, -2, typeLower.constData());
-    lua_getfield(L, -1, typeLower.constData());
-    if (!lua_istable(L, -1)) {
-        return;
-    }
-
-    for (auto it = attrs.cbegin(); it != attrs.cend(); ++it) {
-        lua_pushstring(L, it.value().toUtf8().constData());
-        lua_setfield(L, -2, it.key().toUtf8().toLower().constData());
-    }
-
-    lua_newtable(L);
-    lua_setfield(L, -2, "actions");
-    lua_getfield(L, -1, "actions");
-    for (int i = 0; i < actions.size(); ++i) {
-        lua_pushstring(L, actions[i].toUtf8().constData());
-        lua_rawseti(L, -2, i + 1);
-    }
-    lua_pop(L, 1);
-
-    lua_pushstring(L, caption.toUtf8().constData());
-    lua_setfield(L, -2, "caption");
-
-    lua_pop(L, lua_gettop(L));
-}
+private:
+    lua_State* L = nullptr;
+};
 
 class TLuaMXPEventTest : public QObject {
     Q_OBJECT
 private slots:
     void testCaptionPlacement() {
-        lua_State* L = luaL_newstate();
-        luaL_openlibs(L);
+        TLuaInterpreter interp;
+        lua_State* L = interp.getLuaGlobalState();
 
         QMap<QString, QString> attrs;
         QStringList actions;
         actions << "act1";
-        signalMXPEventForTest(L, "send", attrs, actions, "cap");
+        interp.signalMXPEvent("send", attrs, actions, "cap");
 
         lua_getglobal(L, "mxp");
         lua_getfield(L, -1, "send");
@@ -73,7 +87,6 @@ private slots:
         lua_getfield(L, -1, "actions");
         lua_getfield(L, -1, "caption");
         QVERIFY(lua_isnil(L, -1));
-        lua_close(L);
     }
 };
 


### PR DESCRIPTION
## Summary
- rewrite TLuaMXPEventTest to use a minimal TLuaInterpreter class
- drop helper function and clean up

## Testing
- `cmake ../test -DCMAKE_BUILD_TYPE=Release`
- `make -j$(nproc)`
- `ctest --output-on-failure` *(fails: could not connect to display)*

------
https://chatgpt.com/codex/tasks/task_e_686c7b4ef7c0832b83816129862f1e58