### PR TITLE
Fix MXP caption field

### DIFF
--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3563,6 +3563,7 @@ void TLuaInterpreter::signalMXPEvent(const QString &type, const QMap<QString, QS
         lua_pushstring(L, actions[i].toUtf8().constData());
         lua_rawseti(L, -2, i + 1);
     }
+    lua_pop(L, 1);
 
     lua_pushstring(L, caption.toUtf8().constData());
     lua_setfield(L, -2, "caption");

--- a/src/mudlet-lua/README.md
+++ b/src/mudlet-lua/README.md
@@ -23,3 +23,9 @@ MXP events
 ----------
 
 `mxp.send` events now include a `caption` field with the text between the SEND tags.
+
+The `caption` is available via `mxp.send.caption` and contains the plain text
+displayed when hovering over the element. Commands triggered by the SEND
+element continue to be listed in `mxp.send.actions`, while the optional `href`
+attribute is stored in `mxp.send.href` if present. The nested
+`actions.caption` field that previously held this text no longer exists.


### PR DESCRIPTION
## Summary
- fix the stack cleanup in `signalMXPEvent`
- put caption directly under the MXP event table
- document the `mxp.send.caption` field
- remove temporary unit test added during development

## Testing
- `cmake --build build --target TLuaInterfaceTest` *(fails: build directory missing)*
- `cmake -S test -B build_test` *(fails: could not find Qt6)*


------
https://chatgpt.com/codex/tasks/task_e_686c4473cc0c832ba1e38f64d567d635