### PR TITLE
Add adjustable container wizard

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,6 +60,7 @@ set(mudlet_SRCS
     discord.cpp
     dlgAboutDialog.cpp
     dlgActionMainArea.cpp
+    dlgAdjustableContainer.cpp
     dlgAliasMainArea.cpp
     dlgColorTrigger.cpp
     dlgComposer.cpp
@@ -211,6 +212,7 @@ set(mudlet_UIS
     ui/color_trigger.ui
     ui/composer.ui
     ui/connection_profiles.ui
+    ui/dlgAdjustableContainer.ui
     ui/dlgPackageExporter.ui
     ui/irc.ui
     ui/keybindings_main_area.ui
@@ -241,6 +243,7 @@ set(mudlet_HDRS
     discord.h
     dlgAboutDialog.h
     dlgActionMainArea.h
+    dlgAdjustableContainer.h
     dlgAliasMainArea.h
     dlgColorTrigger.h
     dlgComposer.h

--- a/src/dlgAdjustableContainer.cpp
+++ b/src/dlgAdjustableContainer.cpp
@@ -1,0 +1,70 @@
+/***************************************************************************
+ *   Copyright (C) 2024 by OpenAI                                          *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include "dlgAdjustableContainer.h"
+
+#include "pre_guard.h"
+#include <QString>
+#include "post_guard.h"
+
+dlgAdjustableContainer::dlgAdjustableContainer(QWidget* parent) : QDialog(parent)
+{
+    setupUi(this);
+    connect(buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
+    connect(buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
+}
+
+QString dlgAdjustableContainer::generateCode() const
+{
+    QString container = lineEdit_container_name->text().trimmed();
+    if (container.isEmpty()) {
+        container = qsl("myContainer");
+    }
+
+    QString firstConsole = lineEdit_console1_name->text().trimmed();
+    if (firstConsole.isEmpty()) {
+        firstConsole = qsl("console1");
+    }
+
+    QString secondConsole = lineEdit_console2_name->text().trimmed();
+    if (secondConsole.isEmpty()) {
+        secondConsole = qsl("console2");
+    }
+
+    const bool vertical = comboBox_orientation->currentIndex() == 1;
+
+    QString snippet = qsl("%1 = Adjustable.Container:new({\n"
+                          "  name = \"%1\",\n"
+                          "  x = 0, y = 0,\n"
+                          "  width = \"100%\", height = \"100%\"\n"
+                          "})\n")
+                              .arg(container);
+
+    if (vertical) {
+        snippet += qsl("%2 = Geyser.MiniConsole:new({name=\"%2\", x=\"0%\", y=\"0%\", width=\"100%\", height=\"50%\"}, %1)\n"
+                       "%3 = Geyser.MiniConsole:new({name=\"%3\", x=\"0%\", y=\"50%\", width=\"100%\", height=\"50%\"}, %1)\n")
+                           .arg(container, firstConsole, secondConsole);
+    } else {
+        snippet += qsl("%2 = Geyser.MiniConsole:new({name=\"%2\", x=\"0%\", y=\"0%\", width=\"50%\", height=\"100%\"}, %1)\n"
+                       "%3 = Geyser.MiniConsole:new({name=\"%3\", x=\"50%\", y=\"0%\", width=\"50%\", height=\"100%\"}, %1)\n")
+                           .arg(container, firstConsole, secondConsole);
+    }
+
+    return snippet;
+}

--- a/src/dlgAdjustableContainer.h
+++ b/src/dlgAdjustableContainer.h
@@ -1,0 +1,40 @@
+#ifndef MUDLET_DLGADJUSTABLECONTAINER_H
+#define MUDLET_DLGADJUSTABLECONTAINER_H
+
+/***************************************************************************
+ *   Copyright (C) 2024 by OpenAI                                          *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include "utils.h"
+#include "pre_guard.h"
+#include "ui_dlgAdjustableContainer.h"
+#include <QDialog>
+#include "post_guard.h"
+
+class dlgAdjustableContainer : public QDialog, public Ui::dlgAdjustableContainer
+{
+    Q_OBJECT
+
+public:
+    Q_DISABLE_COPY(dlgAdjustableContainer)
+    explicit dlgAdjustableContainer(QWidget* parent = nullptr);
+
+    QString generateCode() const;
+};
+
+#endif // MUDLET_DLGADJUSTABLECONTAINER_H

--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -36,6 +36,7 @@
 #include "VarUnit.h"
 #include "XMLimport.h"
 #include "dlgActionMainArea.h"
+#include "dlgAdjustableContainer.h"
 #include "dlgAliasMainArea.h"
 #include "dlgColorTrigger.h"
 #include "dlgKeysMainArea.h"
@@ -11001,10 +11002,29 @@ void dlgTriggerEditor::slot_editorContextMenu()
         controller->endUndoGroup(edbee::CoalesceId_None, false);
     });
 
+    auto insertContainerAction = new QAction(tr("Add Adjustable Container"), menu);
+    connect(insertContainerAction, &QAction::triggered, this, &dlgTriggerEditor::slot_insertAdjustableContainer);
     menu->addAction(formatAction);
+    menu->addAction(insertContainerAction);
     menu->exec(QCursor::pos());
 
     delete menu;
+}
+
+void dlgTriggerEditor::slot_insertAdjustableContainer()
+{
+    if (!mpSourceEditorEdbee) {
+        return;
+    }
+
+    dlgAdjustableContainer dlg(this);
+    if (dlg.exec() != QDialog::Accepted) {
+        return;
+    }
+
+    const QString code = dlg.generateCode();
+    auto controller = mpSourceEditorEdbee->controller();
+    controller->insertText(code);
 }
 
 QString dlgTriggerEditor::generateButtonStyleSheet(const QColor& color, const bool isEnabled)

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -309,6 +309,7 @@ private slots:
     void slot_clearSearchResults();
     void slot_clearSoundFile();
     void slot_editorContextMenu();
+    void slot_insertAdjustableContainer();
     void slot_visibilityChangedEditorActionsToolbar();
     void slot_visibilityChangedEditorItemsToolbar();
     void slot_floatingChangedEditorActionsToolbar();

--- a/src/mudlet.pro
+++ b/src/mudlet.pro
@@ -615,6 +615,7 @@ SOURCES += \
     discord.cpp \
     dlgAboutDialog.cpp \
     dlgActionMainArea.cpp \
+    dlgAdjustableContainer.cpp \
     dlgAliasMainArea.cpp \
     dlgColorTrigger.cpp \
     dlgComposer.cpp \
@@ -749,6 +750,7 @@ HEADERS += \
     discord.h \
     dlgAboutDialog.h \
     dlgActionMainArea.h \
+    dlgAdjustableContainer.h \
     dlgAliasMainArea.h \
     dlgColorTrigger.h \
     dlgComposer.h \
@@ -888,6 +890,7 @@ FORMS += \
     ui/color_trigger.ui \
     ui/composer.ui \
     ui/connection_profiles.ui \
+    ui/dlgAdjustableContainer.ui \
     ui/dlgPackageExporter.ui \
     ui/glyph_usage.ui \
     ui/irc.ui \

--- a/src/ui/dlgAdjustableContainer.ui
+++ b/src/ui/dlgAdjustableContainer.ui
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>dlgAdjustableContainer</class>
+ <widget class="QDialog" name="dlgAdjustableContainer">
+  <property name="windowTitle">
+   <string>Add Adjustable Container</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QFormLayout" name="formLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label_container">
+       <property name="text">
+        <string>Container name:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLineEdit" name="lineEdit_container_name"/>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_console1">
+       <property name="text">
+        <string>First console name:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="lineEdit_console1_name"/>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_console2">
+       <property name="text">
+        <string>Second console name:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QLineEdit" name="lineEdit_console2_name"/>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="label_orientation">
+       <property name="text">
+        <string>Orientation:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QComboBox" name="comboBox_orientation">
+       <item>
+        <property name="text">
+         <string>Horizontal</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Vertical</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
## Summary
- introduce `dlgAdjustableContainer` dialog to generate basic adjustable containers with two MiniConsole panes
- hook a new **Add Adjustable Container** action into the script editor's context menu

## Testing
- `cmake .. -G Ninja` *(fails: Could not find a package configuration file provided by "Qt6")*

------
https://chatgpt.com/codex/tasks/task_e_68b3d0fd4954832bad7e7b4dde559a1c