### PR TITLE
feat: add configurable adjustable container

### DIFF
--- a/src/dlgAdjustableContainer.cpp
+++ b/src/dlgAdjustableContainer.cpp
@@ -37,34 +37,25 @@ QString dlgAdjustableContainer::generateCode() const
         container = qsl("myContainer");
     }
 
-    QString firstConsole = lineEdit_console1_name->text().trimmed();
-    if (firstConsole.isEmpty()) {
-        firstConsole = qsl("console1");
+    QString console = lineEdit_console_name->text().trimmed();
+    if (console.isEmpty()) {
+        console = qsl("console1");
     }
 
-    QString secondConsole = lineEdit_console2_name->text().trimmed();
-    if (secondConsole.isEmpty()) {
-        secondConsole = qsl("console2");
+    int fontSize = spinBox_fontsize->value();
+    QString color = lineEdit_color->text().trimmed();
+    if (color.isEmpty()) {
+        color = qsl("black");
     }
-
-    const bool vertical = comboBox_orientation->currentIndex() == 1;
 
     QString snippet = qsl("%1 = Adjustable.Container:new({\n"
                           "  name = \"%1\",\n"
-                          "  x = 0, y = 0,\n"
-                          "  width = \"100%\", height = \"100%\"\n"
-                          "})\n")
-                              .arg(container);
-
-    if (vertical) {
-        snippet += qsl("%2 = Geyser.MiniConsole:new({name=\"%2\", x=\"0%\", y=\"0%\", width=\"100%\", height=\"50%\"}, %1)\n"
-                       "%3 = Geyser.MiniConsole:new({name=\"%3\", x=\"0%\", y=\"50%\", width=\"100%\", height=\"50%\"}, %1)\n")
-                           .arg(container, firstConsole, secondConsole);
-    } else {
-        snippet += qsl("%2 = Geyser.MiniConsole:new({name=\"%2\", x=\"0%\", y=\"0%\", width=\"50%\", height=\"100%\"}, %1)\n"
-                       "%3 = Geyser.MiniConsole:new({name=\"%3\", x=\"50%\", y=\"0%\", width=\"50%\", height=\"100%\"}, %1)\n")
-                           .arg(container, firstConsole, secondConsole);
-    }
+                          "  x = \"-20%\", y = 0,\n"
+                          "  width = \"20%\", height = \"20%\",\n"
+                          "  autoLoad = true,\n"
+                          "})\n"
+                          "%2 = Geyser.MiniConsole:new({name=\"%2\", x=0, y=4, width=\"100%\", height=\"100%-4\", fontSize=%3, color=\"%4\"}, %1)\n")
+                              .arg(container, console, QString::number(fontSize), color);
 
     return snippet;
 }

--- a/src/ui/dlgAdjustableContainer.ui
+++ b/src/ui/dlgAdjustableContainer.ui
@@ -19,44 +19,44 @@
       <widget class="QLineEdit" name="lineEdit_container_name"/>
      </item>
      <item row="1" column="0">
-      <widget class="QLabel" name="label_console1">
+      <widget class="QLabel" name="label_console">
        <property name="text">
-        <string>First console name:</string>
+        <string>Console name:</string>
        </property>
       </widget>
      </item>
      <item row="1" column="1">
-      <widget class="QLineEdit" name="lineEdit_console1_name"/>
+      <widget class="QLineEdit" name="lineEdit_console_name"/>
      </item>
      <item row="2" column="0">
-      <widget class="QLabel" name="label_console2">
+      <widget class="QLabel" name="label_fontsize">
        <property name="text">
-        <string>Second console name:</string>
+        <string>Font size:</string>
        </property>
       </widget>
      </item>
      <item row="2" column="1">
-      <widget class="QLineEdit" name="lineEdit_console2_name"/>
+      <widget class="QSpinBox" name="spinBox_fontsize">
+       <property name="minimum">
+        <number>1</number>
+       </property>
+       <property name="value">
+        <number>9</number>
+       </property>
+      </widget>
      </item>
      <item row="3" column="0">
-      <widget class="QLabel" name="label_orientation">
+      <widget class="QLabel" name="label_color">
        <property name="text">
-        <string>Orientation:</string>
+        <string>Color:</string>
        </property>
       </widget>
      </item>
      <item row="3" column="1">
-      <widget class="QComboBox" name="comboBox_orientation">
-       <item>
-        <property name="text">
-         <string>Horizontal</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Vertical</string>
-        </property>
-       </item>
+      <widget class="QLineEdit" name="lineEdit_color">
+       <property name="text">
+        <string>black</string>
+       </property>
       </widget>
      </item>
     </layout>


### PR DESCRIPTION
## Summary
- Add support to generate a single-console adjustable container sized and positioned at top-right
- Allow user to specify console font size and color

## Testing
- `cmake -S . -B build` *(fails: Could not find a configuration file for package "Qt6" that is compatible with requested version "6.8.2"; found 6.4.2)*

------
https://chatgpt.com/codex/tasks/task_e_68b3e604e1b4832bbb585b988361eaf5