### PR TITLE
Preserve NVDA output focus after Alt+Tab

### DIFF
--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -148,12 +148,16 @@ void TTextEdit::focusInEvent(QFocusEvent* event)
 {
     update();
     QWidget::focusInEvent(event);
+    if (QAccessible::isActive()) {
+        QAccessibleEvent accessibleEvent(this, QAccessible::Focus);
+        QAccessible::updateAccessibility(&accessibleEvent);
+    }
 }
 
 void TTextEdit::focusOutEvent(QFocusEvent* event)
 {
     // Safety check: during destruction, mpHost might be null
-    if (mpHost && mpHost->caretEnabled()) {
+    if (mpHost && mpHost->caretEnabled() && event->reason() != Qt::ActiveWindowFocusReason) {
         mpHost->setCaretEnabled(false);
     }
 


### PR DESCRIPTION
## Summary
- send accessibility focus event when output window gains focus
- keep screen reader caret active when Mudlet is deactivated

## Testing
- `cmake -S . -B build -G Ninja` *(fails: Could not find a configuration file for package "Qt6" that is compatible with requested version "6.8.2".)*

------
https://chatgpt.com/codex/tasks/task_e_68b5bace9ad4832baf0ce7f9fac33589