### PR TITLE
Preserve NVDA output focus after Alt+Tab

### DIFF
--- a/src/Host.cpp
+++ b/src/Host.cpp
@@ -38,6 +38,7 @@
 #include "TCommandLine.h"
 #include "TConsole.h"
 #include "TDebug.h"
+#include "TTextEdit.h"
 #include "TDebug.h"
 #include "TDockWidget.h"
 #include "TEvent.h"
@@ -4448,22 +4449,38 @@ void Host::setFocusOnHostActiveCommandLine()
 
     mFocusTimerRunning = true;
     QTimer::singleShot(0, this, [this]() {
-        auto pCommandLine = activeCommandLine();
-        if (pCommandLine) {
+        QWidget* focusWidget = nullptr;
+        if (caretEnabled() && mpLastFocusedTextEdit) {
+            focusWidget = mpLastFocusedTextEdit;
+        } else if (auto pCommandLine = activeCommandLine()) {
+            focusWidget = pCommandLine;
+        } else {
+            focusWidget = mpConsole->mpCommandLine;
+        }
+
+        if (auto pCommandLine = qobject_cast<TCommandLine*>(focusWidget)) {
             pCommandLine->activateWindow();
             pCommandLine->console()->show();
             pCommandLine->console()->raise();
             pCommandLine->console()->repaint();
-            pCommandLine->setFocus(Qt::OtherFocusReason);
-        } else {
-            mpConsole->mpCommandLine->activateWindow();
-            mpConsole->show();
-            mpConsole->raise();
-            mpConsole->repaint();
-            mpConsole->mpCommandLine->setFocus(Qt::OtherFocusReason);
+        } else if (auto pTextEdit = qobject_cast<TTextEdit*>(focusWidget)) {
+            if (auto pConsole = parentTConsole(pTextEdit)) {
+                pTextEdit->activateWindow();
+                pConsole->show();
+                pConsole->raise();
+                pConsole->repaint();
+            }
+        }
+        if (focusWidget) {
+            focusWidget->setFocus(Qt::OtherFocusReason);
         }
         mFocusTimerRunning = false;
     });
+}
+
+void Host::recordFocusedTextEdit(TTextEdit* pTextEdit)
+{
+    mpLastFocusedTextEdit = pTextEdit;
 }
 
 void Host::recordActiveCommandLine(TCommandLine* pCommandLine)

--- a/src/Host.h
+++ b/src/Host.h
@@ -422,6 +422,7 @@ public:
     void setCaretEnabled(bool enabled);
     void setFocusOnHostActiveCommandLine();
     void recordActiveCommandLine(TCommandLine*);
+    void recordFocusedTextEdit(TTextEdit*);
     void forgetCommandLine(TCommandLine*);
     QPointer<TConsole> parentTConsole(QObject*) const;
     QMargins borders() const { return mBorders; }
@@ -965,6 +966,7 @@ private:
     bool mEditorShowBidi = true;
     // should focus should be on the main window with the caret enabled?
     bool mCaretEnabled = false;
+    QPointer<TTextEdit> mpLastFocusedTextEdit;
 
     // Tracks which command line was last used for this profile so that we can
     // return to it when switching between profiles:

--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -593,6 +593,7 @@ void TCommandLine::focusInEvent(QFocusEvent* event)
     // switching away and back to the Mudlet application and it messes up
     // the record:
     if (event->reason() != Qt::ActiveWindowFocusReason) {
+        mpHost->recordFocusedTextEdit(nullptr);
         mpHost->recordActiveCommandLine(this);
     }
 

--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -148,12 +148,19 @@ void TTextEdit::focusInEvent(QFocusEvent* event)
 {
     update();
     QWidget::focusInEvent(event);
+    if (mpHost && event->reason() != Qt::ActiveWindowFocusReason) {
+        mpHost->recordFocusedTextEdit(this);
+    }
+    if (QAccessible::isActive()) {
+        QAccessibleEvent accessibleEvent(this, QAccessible::Focus);
+        QAccessible::updateAccessibility(&accessibleEvent);
+    }
 }
 
 void TTextEdit::focusOutEvent(QFocusEvent* event)
 {
     // Safety check: during destruction, mpHost might be null
-    if (mpHost && mpHost->caretEnabled()) {
+    if (mpHost && mpHost->caretEnabled() && event->reason() != Qt::ActiveWindowFocusReason) {
         mpHost->setCaretEnabled(false);
     }
 


### PR DESCRIPTION
## Summary
- announce output pane focus changes to assistive tech and remember the last focused text view
- restore focus to the previously read output pane after returning from Alt+Tab
- clear the saved output pane when the command line gains focus

## Testing
- `cmake -S . -B build -G Ninja` *(fails: Could not find a package configuration file for package "Qt6" requested version 6.8.2)*

------
https://chatgpt.com/codex/tasks/task_e_68b5bace9ad4832baf0ce7f9fac33589