### PR TITLE
Preserve NVDA output focus after Alt+Tab

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -43,6 +43,7 @@
 #include "pre_guard.h"
 #include <QAccessibleInterface>
 #include <QAccessibleWidget>
+#include <QAccessibleTextCursorEvent>
 #include <QLineEdit>
 #include <QMessageBox>
 #include <QMimeData>
@@ -50,6 +51,7 @@
 #include <QShortcut>
 #include <QTextBoundaryFinder>
 #include <QTextCodec>
+#include <QTextCursor>
 #include <QPainter>
 #include "post_guard.h"
 
@@ -2302,6 +2304,42 @@ void TConsole::slot_adjustAccessibleNames()
 void TConsole::mouseReleaseEvent(QMouseEvent* event)
 {
     raiseMudletMousePressOrReleaseEvent(event, false);
+}
+
+void TConsole::focusOutEvent(QFocusEvent* event)
+{
+    QWidget::focusOutEvent(event);
+
+    if (mUpperPane && mUpperPane->hasFocus()) {
+        mLastFocusedPane = mUpperPane;
+        mLastCursorPosition = mUpperPane->textCursor().position();
+    } else if (mLowerPane && mLowerPane->hasFocus()) {
+        mLastFocusedPane = mLowerPane;
+        mLastCursorPosition = mLowerPane->textCursor().position();
+    } else {
+        mLastFocusedPane = nullptr;
+    }
+}
+
+void TConsole::focusInEvent(QFocusEvent* event)
+{
+    QWidget::focusInEvent(event);
+
+    if (!mLastFocusedPane) {
+        return;
+    }
+
+    mLastFocusedPane->setFocus(Qt::OtherFocusReason);
+    QTextCursor cursor = mLastFocusedPane->textCursor();
+    cursor.setPosition(mLastCursorPosition);
+    mLastFocusedPane->setTextCursor(cursor);
+
+    if (QAccessible::isActive()) {
+        QAccessibleEvent focusEvent(mLastFocusedPane, QAccessible::Focus);
+        QAccessible::updateAccessibility(&focusEvent);
+        QAccessibleTextCursorEvent cursorEvent(mLastFocusedPane, mLastCursorPosition);
+        QAccessible::updateAccessibility(&cursorEvent);
+    }
 }
 
 void TConsole::slot_changeControlCharacterHandling(const ControlCharacterMode mode)

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -333,6 +333,8 @@ public:
     static const QString cmLuaLineVariable;
     TTextEdit* mUpperPane = nullptr;
     TTextEdit* mLowerPane = nullptr;
+    TTextEdit* mLastFocusedPane = nullptr;
+    int mLastCursorPosition = 0;
 
     QToolButton* emergencyStop = nullptr;
     QWidget* layer = nullptr;
@@ -426,6 +428,8 @@ signals:
     void resized(QResizeEvent* event);
 
 protected:
+    void focusInEvent(QFocusEvent* event) override;
+    void focusOutEvent(QFocusEvent* event) override;
     void dragEnterEvent(QDragEnterEvent*) override;
     void dragMoveEvent(QDragMoveEvent*) override;
     void dropEvent(QDropEvent*) override;


### PR DESCRIPTION
## Summary
- track the last output pane and caret position before Mudlet loses focus
- restore focus and cursor to that text view when returning from Alt+Tab
- announce restored focus and cursor to assistive technologies

## Testing
- `cmake -S . -B build -G Ninja` *(fails: Could not find a package configuration file for package "Qt6" requested version 6.8.2)*

------
https://chatgpt.com/codex/tasks/task_e_68b5bace9ad4832baf0ce7f9fac33589