### PR TITLE
Preserve NVDA output focus after Alt+Tab

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -37,12 +37,14 @@
 #include "TRoomDB.h"
 #include "TSplitter.h"
 #include "TTextEdit.h"
+#include "TAccessibleTextEdit.h"
 #include "dlgMapper.h"
 #include "mudlet.h"
 
 #include "pre_guard.h"
 #include <QAccessibleInterface>
 #include <QAccessibleWidget>
+#include <QAccessibleTextCursorEvent>
 #include <QLineEdit>
 #include <QMessageBox>
 #include <QMimeData>
@@ -2302,6 +2304,50 @@ void TConsole::slot_adjustAccessibleNames()
 void TConsole::mouseReleaseEvent(QMouseEvent* event)
 {
     raiseMudletMousePressOrReleaseEvent(event, false);
+}
+
+void TConsole::focusOutEvent(QFocusEvent* event)
+{
+    QWidget::focusOutEvent(event);
+
+    if (mUpperPane && mUpperPane->hasFocus()) {
+        mLastFocusedPane = mUpperPane;
+        mLastCaretLine = mUpperPane->mCaretLine;
+        mLastCaretColumn = mUpperPane->mCaretColumn;
+    } else if (mLowerPane && mLowerPane->hasFocus()) {
+        mLastFocusedPane = mLowerPane;
+        mLastCaretLine = mLowerPane->mCaretLine;
+        mLastCaretColumn = mLowerPane->mCaretColumn;
+    } else {
+        mLastFocusedPane = nullptr;
+    }
+}
+
+void TConsole::focusInEvent(QFocusEvent* event)
+{
+    QWidget::focusInEvent(event);
+
+    if (!mLastFocusedPane) {
+        return;
+    }
+
+    mLastFocusedPane->setFocus(Qt::OtherFocusReason);
+    mLastFocusedPane->setCaretPosition(mLastCaretLine, mLastCaretColumn);
+    mLastFocusedPane->updateCaret();
+
+    if (QAccessible::isActive()) {
+        QAccessibleEvent focusEvent(mLastFocusedPane, QAccessible::Focus);
+        QAccessible::updateAccessibility(&focusEvent);
+
+        if (QAccessibleInterface* iface = QAccessible::queryAccessibleInterface(mLastFocusedPane)) {
+            if (auto textIface = dynamic_cast<TAccessibleTextEdit*>(iface)) {
+                const int offset = textIface->offsetForPosition(mLastCaretLine, mLastCaretColumn);
+                QAccessibleTextCursorEvent cursorEvent(mLastFocusedPane, offset);
+                QAccessible::updateAccessibility(&cursorEvent);
+            }
+            delete iface;
+        }
+    }
 }
 
 void TConsole::slot_changeControlCharacterHandling(const ControlCharacterMode mode)

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -333,6 +333,9 @@ public:
     static const QString cmLuaLineVariable;
     TTextEdit* mUpperPane = nullptr;
     TTextEdit* mLowerPane = nullptr;
+    TTextEdit* mLastFocusedPane = nullptr;
+    int mLastCaretLine = 0;
+    int mLastCaretColumn = 0;
 
     QToolButton* emergencyStop = nullptr;
     QWidget* layer = nullptr;
@@ -426,6 +429,8 @@ signals:
     void resized(QResizeEvent* event);
 
 protected:
+    void focusInEvent(QFocusEvent* event) override;
+    void focusOutEvent(QFocusEvent* event) override;
     void dragEnterEvent(QDragEnterEvent*) override;
     void dragMoveEvent(QDragMoveEvent*) override;
     void dropEvent(QDropEvent*) override;


### PR DESCRIPTION
## Summary
- track the last output pane and caret position before Mudlet loses focus
- restore focus and cursor to that text view when returning from Alt+Tab
- announce restored focus and cursor to assistive technologies

## Testing
- `cmake -S . -B build -G Ninja` *(fails: Could not find a package configuration file for package "Qt6" requested version 6.8.2)*

------
https://chatgpt.com/codex/tasks/task_e_68b5bace9ad4832baf0ce7f9fac33589