### PR TITLE
Restore focus after alt-tab for screen readers

### DIFF
--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -6374,6 +6374,14 @@ void mudlet::changeEvent(QEvent* event)
     if (event->type() == QEvent::WindowStateChange) {
         emit signal_windowStateChanged(windowState());
     } else if (event->type() == QEvent::ActivationChange) {
+        if (isActiveWindow()) {
+            if (mpFocusWidgetBeforeDeactivate) {
+                mpFocusWidgetBeforeDeactivate->setFocus();
+                mpFocusWidgetBeforeDeactivate.clear();
+            }
+        } else {
+            mpFocusWidgetBeforeDeactivate = QApplication::focusWidget();
+        }
         // Update window menu when window activation changes
         updateWindowMenu();
     }

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -689,6 +689,7 @@ private:
     QHBoxLayout* mpHBoxLayout_profileContainer = nullptr;
     QPointer<QLabel> mpLabelReplaySpeedDisplay;
     QPointer<QLabel> mpLabelReplayTime;
+    QPointer<QWidget> mpFocusWidgetBeforeDeactivate;
     // a list of profiles currently being migrated to secure or profile storage
     QStringList mProfilePasswordsToMigrate;
     // a list of character passwords currently being migrated to secure storage


### PR DESCRIPTION
## Summary
- Track last focused widget when Mudlet loses activation
- Restore focus to the stored widget when reactivating to keep screen readers reading

## Testing
- `cmake .. -G Ninja` *(fails: Could not find Qt6Config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf6c0db4c832bae785f0bbc4dff42