### PR TITLE
Ignore Alt+Tab in command line

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -245,6 +245,11 @@ bool TCommandLine::event(QEvent* event)
             break;
 
         case Qt::Key_Tab:
+            if (ke->modifiers() & Qt::AltModifier) {
+                // Allow system application switching without refocusing the command line
+                return false;
+            }
+
             if ((mpHost->mCaretShortcut == Host::CaretShortcut::Tab && !(ke->modifiers() & Qt::ControlModifier)) ||
                 (mpHost->mCaretShortcut == Host::CaretShortcut::CtrlTab && (ke->modifiers() & Qt::ControlModifier))) {
                 mpHost->setCaretEnabled(true);


### PR DESCRIPTION
## Summary
- avoid focusing the command line when the user uses Alt+Tab

## Testing
- `cmake -S . -B build -G Ninja` *(fails: Could not find a package configuration file provided by "Qt6"...)*

------
https://chatgpt.com/codex/tasks/task_e_68bbfddf3d1c832babb2e3f2876ba5c6