### PR TITLE
Preserve output focus after Alt+Tab with NVDA

### DIFF
--- a/src/TTextEdit.cpp
+++ b/src/TTextEdit.cpp
@@ -153,7 +153,11 @@ void TTextEdit::focusInEvent(QFocusEvent* event)
 void TTextEdit::focusOutEvent(QFocusEvent* event)
 {
     // Safety check: during destruction, mpHost might be null
-    if (mpHost && mpHost->caretEnabled()) {
+    // Avoid disabling caret mode when the window is merely deactivated
+    // (e.g., user Alt+Tabs away). This preserves focus for screen reader
+    // users like NVDA so returning to Mudlet restores the original widget
+    // rather than forcing focus to the command line.
+    if (mpHost && mpHost->caretEnabled() && event->reason() != Qt::ActiveWindowFocusReason) {
         mpHost->setCaretEnabled(false);
     }
 


### PR DESCRIPTION
## Summary
- prevent caret mode from toggling off when the window deactivates so returning from Alt+Tab keeps focus where it was

## Testing
- `cmake .. -G Ninja` *(fails: Could not find a configuration file for package "Qt6" that is compatible with requested version "6.8.2"; found 6.4.2)*

------
https://chatgpt.com/codex/tasks/task_e_68bc0bed232c832b945a66643341bbfd