### PR TITLE
Notify screen readers of spell check underline changes

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -38,6 +38,7 @@
 #include <QRegularExpression>
 #include <QScrollBar>
 #include <QSaveFile>
+#include <QAccessible>
 #include <QToolButton>
 #include <QIcon>
 #include "post_guard.h"
@@ -1267,6 +1268,10 @@ void TCommandLine::spellCheckWord(QTextCursor& c)
     }
     c.setCharFormat(f);
     setTextCursor(c);
+    if (QAccessible::isActive()) {
+        QAccessibleEvent event(this, QAccessible::TextAttributeChanged);
+        QAccessible::updateAccessibility(&event);
+    }
     mSpellChecking = false;
 }
 


### PR DESCRIPTION
## Summary
- Emit a TextAttributeChanged accessibility event whenever spell-check formatting is applied in the command line.
- Include the QAccessible header for access to the event API.

## Testing
- ⚠️ `cmake -S . -B build -G Ninja` *(failed: could not find Qt6Config.cmake)*


------
https://chatgpt.com/codex/tasks/task_e_68c35df56ed8832b93ffa970471d6b4d