### PR TITLE
Spell-check command line after deletions

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -155,14 +155,20 @@ void TCommandLine::processNormalKey(QEvent* event)
         isDelimiter = ch.isSpace() || ch.isPunct();
     }
 
+    const bool isDeletionKey = ke->key() == Qt::Key_Backspace || ke->key() == Qt::Key_Delete;
     bool leftWord = false;
-    if (text.isEmpty() && !isDelimiter) {
+    if (isDeletionKey) {
         const int pos = this->textCursor().position();
         leftWord = pos < wordStart || pos > wordEnd;
     }
 
     if (isDelimiter || leftWord) {
-        spellCheck();
+        QTextCursor currentCursor = textCursor();
+        spellCheckWord(oldCursor);
+        QTextCharFormat f;
+        f.setFontUnderline(false);
+        currentCursor.setCharFormat(f);
+        setTextCursor(currentCursor);
     }
 }
 


### PR DESCRIPTION
## Summary
- handle Backspace and Delete as non-text keys in command line
- spell-check the word left behind after deletions or delimiters

## Testing
- `cmake .. -G Ninja` *(fails: could not find Qt6)*

------
https://chatgpt.com/codex/tasks/task_e_68c415713b68832ba58ed68e80cf3a19