### PR TITLE
Avoid premature spell-check announcements

### DIFF
--- a/src/TCommandLine.cpp
+++ b/src/TCommandLine.cpp
@@ -1214,6 +1214,18 @@ void TCommandLine::spellCheckWord(QTextCursor& c)
     QTextCharFormat f;
     mSpellChecking = true;
     c.select(QTextCursor::WordUnderCursor);
+
+    if (!c.atBlockEnd() && !c.atEnd()) {
+        const QChar nextChar = document()->characterAt(c.position());
+        if (!nextChar.isSpace() && !nextChar.isPunct()) {
+            f.setFontUnderline(false);
+            c.setCharFormat(f);
+            setTextCursor(c);
+            mSpellChecking = false;
+            return;
+        }
+    }
+
     const QTextCharFormat oldFormat = c.charFormat();
     const QString spellCheckedWord = c.selectedText();
     const bool wantSpellCheck = TBuffer::lengthInGraphemes(spellCheckedWord) >= mudlet::self()->mMinLengthForSpellCheck;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -113,3 +113,6 @@ if(USE_OWN_QTKEYCHAIN)
     target_compile_definitions(CredentialManagerTest PRIVATE INCLUDE_OWN_QT6_KEYCHAIN QTKEYCHAIN_NO_EXPORT)
 endif()
 add_test(NAME CredentialManagerTest COMMAND CredentialManagerTest)
+
+add_executable(TCommandLineSpellCheckTest TCommandLineSpellCheckTest.cpp)
+add_test(NAME TCommandLineSpellCheckTest COMMAND TCommandLineSpellCheckTest)

--- a/test/TCommandLineSpellCheckTest.cpp
+++ b/test/TCommandLineSpellCheckTest.cpp
@@ -1,0 +1,163 @@
+#include <QAccessible>
+#include <QPlainTextEdit>
+#include <QTextCodec>
+#include <QtTest/QtTest>
+
+struct Hunhandle {};
+
+int Hunspell_spell(Hunhandle *, const char *word) {
+  return strcmp(word, "helo") != 0;
+}
+
+class DummyConsole {
+public:
+  Hunhandle *getHunspellHandle_system() { return &mHandle; }
+  QTextCodec *getHunspellCodec_system() {
+    return QTextCodec::codecForName("UTF-8");
+  }
+  Hunhandle *getHunspellHandle_user() { return nullptr; }
+
+private:
+  Hunhandle mHandle;
+};
+
+class TestHost {
+public:
+  bool mEnableSpellCheck = true;
+  DummyConsole *mpConsole = nullptr;
+};
+
+class mudlet {
+public:
+  static mudlet *self() {
+    static mudlet instance;
+    return &instance;
+  }
+
+  void announce(const QString &text) { announcements << text; }
+
+  int mMinLengthForSpellCheck = 3;
+  QStringList announcements;
+};
+
+class SpellCheckTestEdit : public QPlainTextEdit {
+public:
+  explicit SpellCheckTestEdit(TestHost *host) : mpHost(host) {}
+
+  void spellCheck() {
+    QTextCursor c = textCursor();
+    if (!mSpellChecking) {
+      spellCheckWord(c);
+    }
+  }
+
+  void spellCheckWord(QTextCursor &c) {
+    if (!mpHost || !mpHost->mEnableSpellCheck) {
+      return;
+    }
+
+    Hunhandle *systemDictionaryHandle =
+        mpHost->mpConsole->getHunspellHandle_system();
+    if (!systemDictionaryHandle) {
+      return;
+    }
+
+    QTextCharFormat f;
+    mSpellChecking = true;
+    c.select(QTextCursor::WordUnderCursor);
+
+    if (!c.atBlockEnd() && !c.atEnd()) {
+      const QChar nextChar = document()->characterAt(c.position());
+      if (!nextChar.isSpace() && !nextChar.isPunct()) {
+        f.setFontUnderline(false);
+        c.setCharFormat(f);
+        setTextCursor(c);
+        mSpellChecking = false;
+        return;
+      }
+    }
+
+    const QTextCharFormat oldFormat = c.charFormat();
+    const QString spellCheckedWord = c.selectedText();
+    const bool wantSpellCheck =
+        spellCheckedWord.length() >= mudlet::self()->mMinLengthForSpellCheck;
+    if (!wantSpellCheck) {
+      f.setFontUnderline(false);
+      c.setCharFormat(f);
+      setTextCursor(c);
+      mSpellChecking = false;
+      return;
+    }
+
+    const QByteArray encodedText =
+        mpHost->mpConsole->getHunspellCodec_system()->fromUnicode(
+            spellCheckedWord);
+    bool isMisspelled = false;
+    if (!Hunspell_spell(systemDictionaryHandle, encodedText.constData())) {
+      f.setUnderlineStyle(QTextCharFormat::SpellCheckUnderline);
+      f.setUnderlineColor(Qt::red);
+      isMisspelled = true;
+    } else {
+      f.setFontUnderline(false);
+    }
+
+    if (isMisspelled && QAccessible::isActive() &&
+        oldFormat.underlineStyle() != QTextCharFormat::SpellCheckUnderline) {
+      mudlet::self()->announce(tr("spelling mistake"));
+    }
+
+    c.setCharFormat(f);
+    setTextCursor(c);
+    mSpellChecking = false;
+  }
+
+  TestHost *mpHost;
+  bool mSpellChecking = false;
+};
+
+static void accessibilityUpdateHandler(QAccessibleEvent *) {}
+
+class TCommandLineSpellCheckTest : public QObject {
+  Q_OBJECT
+private slots:
+  void initTestCase() {
+    qputenv("QT_ACCESSIBILITY", QByteArray("1"));
+    QAccessible::installUpdateHandler(accessibilityUpdateHandler);
+    mHost.mpConsole = &mConsole;
+  }
+
+  void testNoAnnouncementWhileTyping() {
+    mudlet::self()->announcements.clear();
+    SpellCheckTestEdit edit(&mHost);
+    edit.setPlainText("helo");
+    edit.moveCursor(QTextCursor::End);
+    edit.spellCheck();
+    QTextCursor c = edit.textCursor();
+    c.select(QTextCursor::WordUnderCursor);
+    QCOMPARE(c.charFormat().underlineStyle(), QTextCharFormat::NoUnderline);
+    QCOMPARE(mudlet::self()->announcements.size(), 0);
+  }
+
+  void testAnnouncementAfterBoundary() {
+    mudlet::self()->announcements.clear();
+    SpellCheckTestEdit edit(&mHost);
+    edit.setPlainText("helo ");
+    edit.moveCursor(QTextCursor::End);
+    edit.spellCheck();
+    QTextCursor c = edit.textCursor();
+    c.movePosition(QTextCursor::PreviousCharacter);
+    c.select(QTextCursor::WordUnderCursor);
+    QCOMPARE(c.charFormat().underlineStyle(),
+             QTextCharFormat::SpellCheckUnderline);
+    QCOMPARE(mudlet::self()->announcements.size(), 1);
+    QCOMPARE(mudlet::self()->announcements.first(),
+             QStringLiteral("spelling mistake"));
+  }
+
+private:
+  TestHost mHost;
+  DummyConsole mConsole;
+};
+
+QTEST_MAIN(TCommandLineSpellCheckTest)
+#include "TCommandLineSpellCheckTest.moc"


### PR DESCRIPTION
## Summary
- Guard spell checking with a word-boundary check so partial words aren't announced or underlined.
- Add unit tests ensuring no spelling announcement while typing and announcing once a misspelled word is completed.

## Testing
- `cmake -S . -B build` *(failed: Could not find a configuration file for package "Qt6" version 6.8.2)*

------
https://chatgpt.com/codex/tasks/task_e_68c42e97f188832bb3af3a4303348ae5