### PR TITLE
Remove extra empty trigger patterns

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -6263,9 +6263,24 @@ void dlgTriggerEditor::slot_changedPattern()
             showPatternItems(mVisiblePatternCount + 1);
         }
     }
-    updatePatternPlaceholders();
 
+    // Remove trailing blank pattern widgets and keep only one empty pattern
+    int lastActive = -1;
+    for (int i = 0; i < mVisiblePatternCount; ++i) {
+        auto* pItem = mTriggerPatternEdit[i];
+        const bool hasText = !pItem->singleLineTextEdit_pattern->toPlainText().isEmpty();
+        const int type = pItem->comboBox_patternType->currentIndex();
+        if (hasText || type == REGEX_PROMPT || type == REGEX_LINE_SPACER) {
+            lastActive = i;
+        }
+    }
 
+    const int desiredCount = qMax(lastActive + 2, 2);
+    if (desiredCount != mVisiblePatternCount) {
+        showPatternItems(desiredCount);
+    } else {
+        updatePatternPlaceholders();
+    }
 }
 
 // This can get called after the lineEdit contents has changed and it is now a


### PR DESCRIPTION
## Summary
- keep only one extra blank pattern widget after clearing patterns
- clean up trigger editor to prevent unused empty pattern rows

## Testing
- `cmake -S . -B build -G Ninja` *(fails: Could not find a configuration file for package "Qt6" that is compatible with requested version "6.8.2" (found 6.4.2))*

------
https://chatgpt.com/codex/tasks/task_e_68c57ce02bfc832b96321d7774ae4bb9