### PR TITLE
Remove extra empty trigger patterns

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -1121,9 +1121,19 @@ void dlgTriggerEditor::showPatternItems(int count)
         if (i < count) {
             pItem->show();
         } else {
-            pItem->singleLineTextEdit_pattern->clear();
-            lineEditShouldMarkSpaces[pItem->singleLineTextEdit_pattern] = false;
-            pItem->comboBox_patternType->setCurrentIndex(0);
+            // Clear hidden widgets without emitting change signals to
+            // avoid triggering slot_changedPattern recursively
+            auto* edit = pItem->singleLineTextEdit_pattern;
+            edit->blockSignals(true);
+            edit->clear();
+            edit->blockSignals(false);
+            lineEditShouldMarkSpaces[edit] = false;
+
+            auto* combo = pItem->comboBox_patternType;
+            combo->blockSignals(true);
+            combo->setCurrentIndex(0);
+            combo->blockSignals(false);
+
             pItem->pushButton_fgColor->hide();
             pItem->pushButton_bgColor->hide();
             pItem->label_prompt->hide();
@@ -6263,9 +6273,25 @@ void dlgTriggerEditor::slot_changedPattern()
             showPatternItems(mVisiblePatternCount + 1);
         }
     }
-    updatePatternPlaceholders();
 
+    // Remove trailing blank pattern widgets and keep only a single empty
+    // placeholder, mirroring the state of a newly created trigger
+    int lastActive = -1;
+    for (int i = 0; i < mVisiblePatternCount; ++i) {
+        auto* pItem = mTriggerPatternEdit[i];
+        const bool hasText = !pItem->singleLineTextEdit_pattern->toPlainText().isEmpty();
+        const int type = pItem->comboBox_patternType->currentIndex();
+        if (hasText || type == REGEX_PROMPT || type == REGEX_LINE_SPACER) {
+            lastActive = i;
+        }
+    }
 
+    const int desiredCount = qMax(lastActive + 2, 2); // last active + one blank
+    if (desiredCount != mVisiblePatternCount) {
+        showPatternItems(desiredCount);
+    } else {
+        updatePatternPlaceholders();
+    }
 }
 
 // This can get called after the lineEdit contents has changed and it is now a


### PR DESCRIPTION
## Summary
- keep only one extra blank pattern widget after clearing patterns
- prevent crashes when deleting patterns by blocking cleanup signals
- document pattern cleanup logic for future developers

## Testing
- `cmake -S . -B build -G Ninja` *(fails: Could not find a package configuration file for package "Qt6" that is compatible with requested version "6.8.2" (found 6.4.2))*


------
https://chatgpt.com/codex/tasks/task_e_68c57ce02bfc832b96321d7774ae4bb9