### PR TITLE
Fix trigger editor pattern theming and hints

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -1155,6 +1155,7 @@ void dlgTriggerEditor::createPatternItem(int index)
     font.setPixelSize(pItem->singleLineTextEdit_pattern->height() / 2);
     pItem->singleLineTextEdit_pattern->setFont(font);
     pItem->singleLineTextEdit_pattern->installEventFilter(this);
+    pItem->singleLineTextEdit_pattern->setTheme(mpHost->mEditorTheme);
     pItem->spinBox_lineSpacer->installEventFilter(this);
 }
 
@@ -1197,15 +1198,41 @@ void dlgTriggerEditor::showPatternItems(int count)
 void dlgTriggerEditor::updatePatternPlaceholders()
 {
     for (int i = 0; i < mVisiblePatternCount; ++i) {
-        mTriggerPatternEdit[i]->singleLineTextEdit_pattern->setPlaceholderText(QString());
-    }
-
-    for (int i = 0; i < mVisiblePatternCount; ++i) {
-        auto* edit = mTriggerPatternEdit[i]->singleLineTextEdit_pattern;
-        if (edit->toPlainText().isEmpty()) {
-            edit->setPlaceholderText(tr("Text to find (anywhere in the game output)"));
-            break;
+        auto* patternItem = mTriggerPatternEdit.value(i, nullptr);
+        if (!patternItem) {
+            continue;
         }
+
+        auto* edit = patternItem->singleLineTextEdit_pattern;
+        if (!edit) {
+            continue;
+        }
+
+        if (!edit->isVisible() || !edit->toPlainText().isEmpty()) {
+            edit->setPlaceholderText(QString());
+            continue;
+        }
+
+        const QString placeholder = patternPlaceholderText(patternItem->comboBox_patternType->currentIndex());
+        edit->setPlaceholderText(placeholder);
+    }
+}
+
+QString dlgTriggerEditor::patternPlaceholderText(const int patternType) const
+{
+    switch (patternType) {
+    case REGEX_SUBSTRING:
+        return tr("Text to find (anywhere in the game output)");
+    case REGEX_PERL:
+        return tr("Text to find (as a regular expression pattern)");
+    case REGEX_BEGIN_OF_LINE_SUBSTRING:
+        return tr("Text to find (from beginning of the line)");
+    case REGEX_EXACT_MATCH:
+        return tr("Exact line to match");
+    case REGEX_LUA_CODE:
+        return tr("Lua code to run (return true to match)");
+    default:
+        return QString();
     }
 }
 
@@ -6389,6 +6416,7 @@ void dlgTriggerEditor::setupPatternControls(const int type, dlgTriggerPatternEdi
 
     checkForMoreThanOneTriggerItem();
     updatePatternTabOrder();
+    updatePatternPlaceholders();
 }
 
 void dlgTriggerEditor::handlePatternChange(dlgTriggerPatternEdit* patternItem, bool hasContentHint)

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -466,6 +466,7 @@ private:
     void createPatternItem(int index);
     void showPatternItems(int count);
     void updatePatternPlaceholders();
+    [[nodiscard]] QString patternPlaceholderText(int patternType) const;
     void handlePatternChange(dlgTriggerPatternEdit* patternItem, bool hasContentHint);
 
     void keyGrabCallback(const Qt::Key, const Qt::KeyboardModifiers);

--- a/src/dlgTriggerPatternEdit.cpp
+++ b/src/dlgTriggerPatternEdit.cpp
@@ -21,11 +21,8 @@
 
 
 #include "dlgTriggerPatternEdit.h"
-#include "TTrigger.h"
 
 #include "pre_guard.h"
-#include <QAction>
-#include <QDebug>
 #include "post_guard.h"
 
 dlgTriggerPatternEdit::dlgTriggerPatternEdit(QWidget* pParentWidget)
@@ -41,26 +38,4 @@ void dlgTriggerPatternEdit::slot_triggerTypeComboBoxChanged(const int index)
 {
     label_colorIcon->setPixmap(comboBox_patternType->itemIcon(index).pixmap(15, 15));
 
-    const bool firstRow = comboBox_patternType->itemData(0).toInt() == 0;
-    if (!firstRow) {
-        return;
-    }
-
-    switch (comboBox_patternType->currentIndex()) {
-    case REGEX_SUBSTRING:
-        singleLineTextEdit_pattern->setPlaceholderText(tr("Text to find (anywhere in the game output)"));
-        break;
-    case REGEX_PERL:
-        singleLineTextEdit_pattern->setPlaceholderText(tr("Text to find (as a regular expression pattern)"));
-        break;
-    case REGEX_BEGIN_OF_LINE_SUBSTRING:
-        singleLineTextEdit_pattern->setPlaceholderText(tr("Text to find (from beginning of the line)"));
-        break;
-    case REGEX_EXACT_MATCH:
-        singleLineTextEdit_pattern->setPlaceholderText(tr("Exact line to match"));
-        break;
-    case REGEX_LUA_CODE:
-        singleLineTextEdit_pattern->setPlaceholderText(tr("Lua code to run (return true to match)"));
-        break;
-    }
 }


### PR DESCRIPTION
## Summary
- apply the editor theme to newly created trigger pattern entries so newly added fields respect dark mode
- refresh trigger pattern placeholders per row so empty fields show the correct hint for their selected type
- simplify the trigger pattern widget placeholder handling now that the editor drives the hints

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68cc52948134832b98d4d4438e230241