### PR TITLE
Fix keyboard paste handling in tree widgets

### DIFF
--- a/src/TTreeWidget.cpp
+++ b/src/TTreeWidget.cpp
@@ -30,6 +30,7 @@
 #include "pre_guard.h"
 #include <QtEvents>
 #include <QHeaderView>
+#include <QKeySequence>
 #include "post_guard.h"
 
 TTreeWidget::TTreeWidget(QWidget* pW)
@@ -173,6 +174,16 @@ void TTreeWidget::mouseReleaseEvent(QMouseEvent* event)
         }
     }
     QTreeWidget::mouseReleaseEvent(event);
+}
+
+void TTreeWidget::keyPressEvent(QKeyEvent* event)
+{
+    if (event->matches(QKeySequence::Copy) || event->matches(QKeySequence::Paste) || event->matches(QKeySequence::Cut)) {
+        event->accept();
+        return;
+    }
+
+    QTreeWidget::keyPressEvent(event);
 }
 
 void TTreeWidget::mousePressEvent(QMouseEvent* event)

--- a/src/TTreeWidget.h
+++ b/src/TTreeWidget.h
@@ -28,6 +28,7 @@
 #include <QTreeWidget>
 #include "post_guard.h"
 
+class QKeyEvent;
 class Host;
 
 
@@ -60,6 +61,9 @@ public:
     void setIsKeyTree();
     void beginInsertRows(const QModelIndex& parent, int first, int last);
     void getAllChildren(QTreeWidgetItem*, QList<QTreeWidgetItem*>&);
+
+protected:
+    void keyPressEvent(QKeyEvent* event) override;
 
 private:
     bool mIsDropAction;


### PR DESCRIPTION
## Summary
- stop TTreeWidget from running its default copy, cut, and paste key handlers so the editor actions keep clipboard data intact

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ced34e5e90832bb04be463cc976037