### PR TITLE
Allow trigger tree shortcuts to reach dialog actions

### DIFF
--- a/src/TTreeWidget.cpp
+++ b/src/TTreeWidget.cpp
@@ -28,8 +28,10 @@
 #include "VarUnit.h"
 
 #include "pre_guard.h"
-#include <QtEvents>
 #include <QHeaderView>
+#include <QKeyEvent>
+#include <QKeySequence>
+#include <QtEvents>
 #include "post_guard.h"
 
 TTreeWidget::TTreeWidget(QWidget* pW)
@@ -54,6 +56,19 @@ TTreeWidget::TTreeWidget(QWidget* pW)
     mIsActionTree = false;
     mIsKeyTree = false;
     mIsVarTree = false;
+}
+
+bool TTreeWidget::event(QEvent* event)
+{
+    if (event->type() == QEvent::ShortcutOverride) {
+        auto* keyEvent = static_cast<QKeyEvent*>(event);
+        if (keyEvent->matches(QKeySequence::Copy) || keyEvent->matches(QKeySequence::Cut) || keyEvent->matches(QKeySequence::Paste)) {
+            event->ignore();
+            return false;
+        }
+    }
+
+    return QTreeWidget::event(event);
 }
 
 void TTreeWidget::setIsAliasTree()
@@ -138,6 +153,16 @@ void TTreeWidget::getAllChildren(QTreeWidgetItem* pItem, QList<QTreeWidgetItem*>
     for (int i = 0; i < pItem->childCount(); ++i) {
         getAllChildren(pItem->child(i), list);
     }
+}
+
+void TTreeWidget::keyPressEvent(QKeyEvent* event)
+{
+    if (event->matches(QKeySequence::Copy) || event->matches(QKeySequence::Cut) || event->matches(QKeySequence::Paste)) {
+        event->ignore();
+        return;
+    }
+
+    QTreeWidget::keyPressEvent(event);
 }
 
 void TTreeWidget::mouseReleaseEvent(QMouseEvent* event)

--- a/src/TTreeWidget.h
+++ b/src/TTreeWidget.h
@@ -24,6 +24,8 @@
 
 
 #include "pre_guard.h"
+#include <QEvent>
+#include <QKeyEvent>
 #include <QPointer>
 #include <QTreeWidget>
 #include "post_guard.h"
@@ -61,7 +63,12 @@ public:
     void beginInsertRows(const QModelIndex& parent, int first, int last);
     void getAllChildren(QTreeWidgetItem*, QList<QTreeWidgetItem*>&);
 
+protected:
+    bool event(QEvent* event) override;
+    void keyPressEvent(QKeyEvent* event) override;
+
 private:
+
     bool mIsDropAction;
     QPointer<Host> mpHost;
     int mOldParentID;


### PR DESCRIPTION
## Summary
- ignore copy, cut, and paste shortcut overrides within TTreeWidget so dlgTriggerEditor actions receive them
- bypass TTreeWidget key press handling for copy, cut, and paste so the dialog's QAction shortcuts fire instead

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cf05347dc8832b9fa894c4a7b7d9ae