### PR TITLE
Fix dark theme styling for trigger pattern entries

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -1159,9 +1159,8 @@ void dlgTriggerEditor::createPatternItem(int index)
 
     lineEditShouldMarkSpaces[pItem->singleLineTextEdit_pattern] = false;
 
-    QFont font = mpHost->getDisplayFont();
-    font.setPixelSize(pItem->singleLineTextEdit_pattern->height() / 2);
-    pItem->singleLineTextEdit_pattern->setFont(font);
+    QFont patternFont = mpHost->getDisplayFont();
+    pItem->singleLineTextEdit_pattern->setFont(patternFont);
     pItem->singleLineTextEdit_pattern->installEventFilter(this);
     pItem->singleLineTextEdit_pattern->setTheme(mpHost->mEditorTheme);
     pItem->spinBox_lineSpacer->installEventFilter(this);

--- a/src/dlgTriggerPatternEdit.cpp
+++ b/src/dlgTriggerPatternEdit.cpp
@@ -23,6 +23,7 @@
 #include "dlgTriggerPatternEdit.h"
 
 #include "pre_guard.h"
+#include <QPalette>
 #include "post_guard.h"
 
 dlgTriggerPatternEdit::dlgTriggerPatternEdit(QWidget* pParentWidget)
@@ -30,6 +31,12 @@ dlgTriggerPatternEdit::dlgTriggerPatternEdit(QWidget* pParentWidget)
 {
     // init generated dialog
     setupUi(this);
+
+    // Ensure the widget background follows the active editor theme instead of
+    // keeping the default bright palette in dark mode.
+    setAutoFillBackground(true);
+    setBackgroundRole(QPalette::Base);
+
     // delay the connection so the pattern type is available for the slot
     connect(comboBox_patternType, qOverload<int>(&QComboBox::currentIndexChanged), this, &dlgTriggerPatternEdit::slot_triggerTypeComboBoxChanged, Qt::QueuedConnection);
 }

--- a/src/ui/trigger_pattern_edit.ui
+++ b/src/ui/trigger_pattern_edit.ui
@@ -109,11 +109,6 @@
        <height>29</height>
       </size>
      </property>
-     <property name="font">
-      <font>
-       <pointsize>7</pointsize>
-      </font>
-     </property>
      <property name="text">
       <string>Foreground color ignored</string>
      </property>
@@ -132,11 +127,6 @@
        <width>16777215</width>
        <height>29</height>
       </size>
-     </property>
-     <property name="font">
-      <font>
-       <pointsize>7</pointsize>
-      </font>
      </property>
      <property name="text">
       <string>Background color ignored</string>
@@ -159,11 +149,6 @@
        <width>16777215</width>
        <height>29</height>
       </size>
-     </property>
-     <property name="font">
-      <font>
-       <pointsize>7</pointsize>
-      </font>
      </property>
      <property name="text">
       <string>match on the prompt line</string>


### PR DESCRIPTION
## Summary
- ensure trigger pattern rows use the themed background in dark mode
- align the pattern editor controls' fonts with the rest of the trigger editor

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e1ae6d53a8832b86076df94e531b5d