### PR TITLE
Keep line spacer rows visible after clearing later patterns

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -6578,7 +6578,8 @@ void dlgTriggerEditor::handlePatternChange(dlgTriggerPatternEdit* patternItem, b
         if (type == REGEX_PROMPT) {
             itemHasContent = true;
         } else if (type == REGEX_LINE_SPACER) {
-            itemHasContent = item->spinBox_lineSpacer->value() > 0;
+            itemHasContent = item->spinBox_lineSpacer->value() > 0
+                             || item->spinBox_lineSpacer->isVisible();
             if (forceLineSpacerActive && item == patternItem) {
                 itemHasContent = true;
             }


### PR DESCRIPTION
## Summary
- ensure line spacer patterns count as content while their controls are visible
- keep the following pattern row available even if later text entries are cleared

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1b63f04e8832ba19d5ced7a46e777