### PR TITLE
Fix dark theme styling for trigger pattern entries

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -1117,7 +1117,9 @@ void dlgTriggerEditor::slot_clickedMessageBox(const QString& URL)
 void dlgTriggerEditor::slot_editorThemeChanged()
 {
     for (int i = 0; i < mTriggerPatternEdit.size(); i++) {
-        mTriggerPatternEdit.at(i)->singleLineTextEdit_pattern->setTheme(mpHost->mEditorTheme);
+        auto* patternWidget = mTriggerPatternEdit.at(i);
+        patternWidget->singleLineTextEdit_pattern->setTheme(mpHost->mEditorTheme);
+        patternWidget->applyThemePalette(patternWidget->singleLineTextEdit_pattern->palette());
     }
 }
 
@@ -1159,11 +1161,11 @@ void dlgTriggerEditor::createPatternItem(int index)
 
     lineEditShouldMarkSpaces[pItem->singleLineTextEdit_pattern] = false;
 
-    QFont font = mpHost->getDisplayFont();
-    font.setPixelSize(pItem->singleLineTextEdit_pattern->height() / 2);
-    pItem->singleLineTextEdit_pattern->setFont(font);
+    QFont patternFont = mpHost->getDisplayFont();
+    pItem->singleLineTextEdit_pattern->setFont(patternFont);
     pItem->singleLineTextEdit_pattern->installEventFilter(this);
     pItem->singleLineTextEdit_pattern->setTheme(mpHost->mEditorTheme);
+    pItem->applyThemePalette(pItem->singleLineTextEdit_pattern->palette());
     pItem->spinBox_lineSpacer->installEventFilter(this);
 }
 

--- a/src/dlgTriggerPatternEdit.cpp
+++ b/src/dlgTriggerPatternEdit.cpp
@@ -23,6 +23,9 @@
 #include "dlgTriggerPatternEdit.h"
 
 #include "pre_guard.h"
+#include <QColor>
+#include <QPalette>
+#include <QWidget>
 #include "post_guard.h"
 
 dlgTriggerPatternEdit::dlgTriggerPatternEdit(QWidget* pParentWidget)
@@ -30,6 +33,15 @@ dlgTriggerPatternEdit::dlgTriggerPatternEdit(QWidget* pParentWidget)
 {
     // init generated dialog
     setupUi(this);
+
+    mDefaultPalette = palette();
+    mDefaultPatternNumberPalette = label_patternNumber->palette();
+    mDefaultPromptPalette = label_prompt->palette();
+    mDefaultComboPalette = comboBox_patternType->palette();
+    mDefaultSpinPalette = spinBox_lineSpacer->palette();
+    mDefaultForegroundButtonPalette = pushButton_fgColor->palette();
+    mDefaultBackgroundButtonPalette = pushButton_bgColor->palette();
+
     // delay the connection so the pattern type is available for the slot
     connect(comboBox_patternType, qOverload<int>(&QComboBox::currentIndexChanged), this, &dlgTriggerPatternEdit::slot_triggerTypeComboBoxChanged, Qt::QueuedConnection);
 }
@@ -38,4 +50,59 @@ void dlgTriggerPatternEdit::slot_triggerTypeComboBoxChanged(const int index)
 {
     label_colorIcon->setPixmap(comboBox_patternType->itemIcon(index).pixmap(15, 15));
 
+}
+
+void dlgTriggerPatternEdit::applyThemePalette(const QPalette& editorPalette)
+{
+    const QColor baseColor = editorPalette.color(QPalette::Base);
+    const QColor textColor = editorPalette.color(QPalette::Text);
+
+    if (!baseColor.isValid() || !textColor.isValid() || baseColor.lightness() >= 128) {
+        resetThemePalette();
+        return;
+    }
+
+    QPalette framePalette = mDefaultPalette;
+    framePalette.setColor(QPalette::Window, baseColor);
+    framePalette.setColor(QPalette::Base, baseColor);
+    framePalette.setColor(QPalette::AlternateBase, baseColor);
+    framePalette.setColor(QPalette::WindowText, textColor);
+    framePalette.setColor(QPalette::Text, textColor);
+    framePalette.setColor(QPalette::Button, baseColor);
+    framePalette.setColor(QPalette::ButtonText, textColor);
+
+    setPalette(framePalette);
+    setAutoFillBackground(true);
+
+    auto applyToWidget = [&](QWidget* widget, const QPalette& defaultPalette) {
+        QPalette widgetPalette = defaultPalette;
+        widgetPalette.setColor(QPalette::Window, baseColor);
+        widgetPalette.setColor(QPalette::Base, baseColor);
+        widgetPalette.setColor(QPalette::AlternateBase, baseColor);
+        widgetPalette.setColor(QPalette::Text, textColor);
+        widgetPalette.setColor(QPalette::WindowText, textColor);
+        widgetPalette.setColor(QPalette::Button, baseColor);
+        widgetPalette.setColor(QPalette::ButtonText, textColor);
+        widget->setPalette(widgetPalette);
+    };
+
+    applyToWidget(label_patternNumber, mDefaultPatternNumberPalette);
+    applyToWidget(label_prompt, mDefaultPromptPalette);
+    applyToWidget(comboBox_patternType, mDefaultComboPalette);
+    applyToWidget(spinBox_lineSpacer, mDefaultSpinPalette);
+    applyToWidget(pushButton_fgColor, mDefaultForegroundButtonPalette);
+    applyToWidget(pushButton_bgColor, mDefaultBackgroundButtonPalette);
+}
+
+void dlgTriggerPatternEdit::resetThemePalette()
+{
+    setAutoFillBackground(false);
+    setPalette(mDefaultPalette);
+
+    label_patternNumber->setPalette(mDefaultPatternNumberPalette);
+    label_prompt->setPalette(mDefaultPromptPalette);
+    comboBox_patternType->setPalette(mDefaultComboPalette);
+    spinBox_lineSpacer->setPalette(mDefaultSpinPalette);
+    pushButton_fgColor->setPalette(mDefaultForegroundButtonPalette);
+    pushButton_bgColor->setPalette(mDefaultBackgroundButtonPalette);
 }

--- a/src/dlgTriggerPatternEdit.h
+++ b/src/dlgTriggerPatternEdit.h
@@ -25,6 +25,7 @@
 
 #include "pre_guard.h"
 #include "ui_trigger_pattern_edit.h"
+#include <QPalette>
 #include "post_guard.h"
 
 class QAction;
@@ -37,6 +38,8 @@ public:
     Q_DISABLE_COPY(dlgTriggerPatternEdit)
     explicit dlgTriggerPatternEdit(QWidget*);
 
+    void applyThemePalette(const QPalette& editorPalette);
+
     int mRow = 0;
 
 
@@ -44,6 +47,16 @@ public slots:
     void slot_triggerTypeComboBoxChanged(const int);
 
 
+private:
+    void resetThemePalette();
+
+    QPalette mDefaultPalette;
+    QPalette mDefaultPatternNumberPalette;
+    QPalette mDefaultPromptPalette;
+    QPalette mDefaultComboPalette;
+    QPalette mDefaultSpinPalette;
+    QPalette mDefaultForegroundButtonPalette;
+    QPalette mDefaultBackgroundButtonPalette;
 };
 
 #endif // MUDLET_DLGTRIGGERPATTERNEDIT_H

--- a/src/ui/trigger_pattern_edit.ui
+++ b/src/ui/trigger_pattern_edit.ui
@@ -109,11 +109,6 @@
        <height>29</height>
       </size>
      </property>
-     <property name="font">
-      <font>
-       <pointsize>7</pointsize>
-      </font>
-     </property>
      <property name="text">
       <string>Foreground color ignored</string>
      </property>
@@ -132,11 +127,6 @@
        <width>16777215</width>
        <height>29</height>
       </size>
-     </property>
-     <property name="font">
-      <font>
-       <pointsize>7</pointsize>
-      </font>
      </property>
      <property name="text">
       <string>Background color ignored</string>
@@ -159,11 +149,6 @@
        <width>16777215</width>
        <height>29</height>
       </size>
-     </property>
-     <property name="font">
-      <font>
-       <pointsize>7</pointsize>
-      </font>
      </property>
      <property name="text">
       <string>match on the prompt line</string>


### PR DESCRIPTION
## Summary
- keep trigger pattern rows using the themed background in dark mode without affecting the light theme appearance
- keep the pattern editor controls aligned with the profile display font

## Testing
- not run (UI change only)

------
https://chatgpt.com/codex/tasks/task_e_68e1ae6d53a8832b86076df94e531b5d