### PR TITLE
Fix pattern navigation hint restoration with legacy settings

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -1607,6 +1607,13 @@ void dlgTriggerEditor::readSettings()
     mSearchSplitterState = settings.value("mSearchSplitterState", QByteArray()).toByteArray();
 
     mPatternNavigationHintHidden = settings.value(qsl("patternNavigationHintHidden"), false).toBool();
+
+    const bool permanentlyHidden = bannerPermanentlyHidden(EditorViewType::cmTriggerView, patternNavigationBannerKey);
+    if (mPatternNavigationHintHidden && !permanentlyHidden) {
+        mPatternNavigationHintHidden = false;
+        settings.setValue(qsl("patternNavigationHintHidden"), false);
+        updatePatternNavigationHint();
+    }
 }
 
 void dlgTriggerEditor::writeSettings()


### PR DESCRIPTION
## Summary
- ensure the trigger editor consults the permanent banner preference when restoring the pattern hint state
- reset the stored hidden flag and refresh the banner when the permanent preference is unset

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1f89210c0832b928787dced1b44ed