### PR TITLE
Align trigger pattern editor font and palette

### DIFF
--- a/src/SingleLineTextEdit.cpp
+++ b/src/SingleLineTextEdit.cpp
@@ -82,13 +82,19 @@ void SingleLineTextEdit::setTheme(const QString& themeName)
 
     // set the textedit background and text the same as edbee base settings
     QPalette p = palette();
+    const QColor backgroundColor = theme->backgroundColor();
+    const QColor foregroundColor = theme->foregroundColor();
+    p.setColor(QPalette::Window, backgroundColor);
     p.setColor(QPalette::Base, theme->backgroundColor()); // background
-    p.setColor(QPalette::Text, theme->foregroundColor());
+    p.setColor(QPalette::Text, foregroundColor);
+    p.setColor(QPalette::WindowText, foregroundColor);
+    p.setColor(QPalette::ButtonText, foregroundColor);
 
-    QColor placeholderColor = theme->foregroundColor();
+    QColor placeholderColor = foregroundColor;
     placeholderColor.setAlphaF(0.6);
     p.setColor(QPalette::PlaceholderText, placeholderColor);
     setPalette(p);
+    setAutoFillBackground(true);
     viewport()->setPalette(p);
     viewport()->setAutoFillBackground(true);
 

--- a/src/dlgTriggerPatternEdit.cpp
+++ b/src/dlgTriggerPatternEdit.cpp
@@ -30,6 +30,7 @@
 #include <QPlainTextEdit>
 #include <QColor>
 #include <QComboBox>
+#include <QFont>
 #include <QLineEdit>
 #include <QPalette>
 #include <QWidget>
@@ -74,10 +75,8 @@ void dlgTriggerPatternEdit::applyThemePalette(const QPalette& editorPalette)
         return;
     }
 
-    if (baseColor.lightness() >= textColor.lightness()) {
-        resetThemePalette();
-        return;
-    }
+    const QFont patternFont = singleLineTextEdit_pattern->font();
+    setFont(patternFont);
 
     auto makePalette = [&](QPalette palette) {
         const QColor alternateBase = editorPalette.color(QPalette::AlternateBase).isValid() ? editorPalette.color(QPalette::AlternateBase) : baseColor;
@@ -115,16 +114,19 @@ void dlgTriggerPatternEdit::applyThemePalette(const QPalette& editorPalette)
     auto applyToWidget = [&](QWidget* widget) {
         QPalette widgetPalette = makePalette(editorPalette);
         widget->setPalette(widgetPalette);
+        widget->setFont(patternFont);
 
         if (auto* spinBox = qobject_cast<QAbstractSpinBox*>(widget)) {
             if (auto* lineEdit = spinBox->findChild<QLineEdit*>()) {
                 lineEdit->setPalette(widgetPalette);
+                lineEdit->setFont(patternFont);
             }
         }
 
         if (auto* comboBox = qobject_cast<QComboBox*>(widget)) {
             if (auto* view = comboBox->view()) {
                 view->setPalette(widgetPalette);
+                view->setFont(patternFont);
             }
         }
 
@@ -136,11 +138,13 @@ void dlgTriggerPatternEdit::applyThemePalette(const QPalette& editorPalette)
             if (auto* viewport = plainTextEdit->viewport()) {
                 viewport->setPalette(widgetPalette);
                 viewport->setAutoFillBackground(true);
+                viewport->setFont(patternFont);
             }
         } else if (auto* scrollArea = qobject_cast<QAbstractScrollArea*>(widget)) {
             if (auto* viewport = scrollArea->viewport()) {
                 viewport->setPalette(widgetPalette);
                 viewport->setAutoFillBackground(true);
+                viewport->setFont(patternFont);
             }
         }
     };


### PR DESCRIPTION
## Summary
- ensure the trigger pattern SingleLineTextEdit uses the active theme palette for all foreground roles and background fill
- propagate the editor font and palette to each trigger pattern widget child so text size and color matches the rest of the editor

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68e225ce71a8832bbe10213b0f69aea1