### PR TITLE
Restore trigger pattern font scope

### DIFF
--- a/src/SingleLineTextEdit.cpp
+++ b/src/SingleLineTextEdit.cpp
@@ -82,13 +82,19 @@ void SingleLineTextEdit::setTheme(const QString& themeName)
 
     // set the textedit background and text the same as edbee base settings
     QPalette p = palette();
+    const QColor backgroundColor = theme->backgroundColor();
+    const QColor foregroundColor = theme->foregroundColor();
+    p.setColor(QPalette::Window, backgroundColor);
     p.setColor(QPalette::Base, theme->backgroundColor()); // background
-    p.setColor(QPalette::Text, theme->foregroundColor());
+    p.setColor(QPalette::Text, foregroundColor);
+    p.setColor(QPalette::WindowText, foregroundColor);
+    p.setColor(QPalette::ButtonText, foregroundColor);
 
-    QColor placeholderColor = theme->foregroundColor();
+    QColor placeholderColor = foregroundColor;
     placeholderColor.setAlphaF(0.6);
     p.setColor(QPalette::PlaceholderText, placeholderColor);
     setPalette(p);
+    setAutoFillBackground(true);
     viewport()->setPalette(p);
     viewport()->setAutoFillBackground(true);
 

--- a/src/dlgTriggerPatternEdit.cpp
+++ b/src/dlgTriggerPatternEdit.cpp
@@ -30,6 +30,7 @@
 #include <QPlainTextEdit>
 #include <QColor>
 #include <QComboBox>
+#include <QFont>
 #include <QLineEdit>
 #include <QPalette>
 #include <QWidget>
@@ -78,6 +79,8 @@ void dlgTriggerPatternEdit::applyThemePalette(const QPalette& editorPalette)
         resetThemePalette();
         return;
     }
+
+    const QFont patternFont = singleLineTextEdit_pattern->font();
 
     auto makePalette = [&](QPalette palette) {
         const QColor alternateBase = editorPalette.color(QPalette::AlternateBase).isValid() ? editorPalette.color(QPalette::AlternateBase) : baseColor;
@@ -152,6 +155,11 @@ void dlgTriggerPatternEdit::applyThemePalette(const QPalette& editorPalette)
     applyToWidget(pushButton_fgColor);
     applyToWidget(pushButton_bgColor);
     applyToWidget(singleLineTextEdit_pattern);
+
+    singleLineTextEdit_pattern->setFont(patternFont);
+    if (auto* patternViewport = singleLineTextEdit_pattern->viewport()) {
+        patternViewport->setFont(patternFont);
+    }
 }
 
 void dlgTriggerPatternEdit::resetThemePalette()


### PR DESCRIPTION
## Summary
- ensure the trigger pattern SingleLineTextEdit continues to use the editor theme palette with appropriate contrast checks
- confine the command-line font to the trigger pattern input so surrounding widgets retain their original styling

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68e225ce71a8832bbe10213b0f69aea1