### PR TITLE
Adjust trigger pattern widget fonts

### DIFF
--- a/src/dlgTriggerPatternEdit.cpp
+++ b/src/dlgTriggerPatternEdit.cpp
@@ -75,9 +75,6 @@ void dlgTriggerPatternEdit::applyThemePalette(const QPalette& editorPalette)
         return;
     }
 
-    const QFont patternFont = singleLineTextEdit_pattern->font();
-    setFont(patternFont);
-    
     auto makePalette = [&](QPalette palette) {
         const QColor alternateBase = editorPalette.color(QPalette::AlternateBase).isValid() ? editorPalette.color(QPalette::AlternateBase) : baseColor;
         const QColor buttonColor = editorPalette.color(QPalette::Button).isValid() ? editorPalette.color(QPalette::Button) : baseColor;
@@ -111,22 +108,21 @@ void dlgTriggerPatternEdit::applyThemePalette(const QPalette& editorPalette)
     setPalette(darkPalette);
     setAutoFillBackground(true);
 
+    const QFont patternFont = singleLineTextEdit_pattern->font();
+
     auto applyToWidget = [&](QWidget* widget) {
         QPalette widgetPalette = makePalette(editorPalette);
         widget->setPalette(widgetPalette);
-        widget->setFont(patternFont);
 
         if (auto* spinBox = qobject_cast<QAbstractSpinBox*>(widget)) {
             if (auto* lineEdit = spinBox->findChild<QLineEdit*>()) {
                 lineEdit->setPalette(widgetPalette);
-                lineEdit->setFont(patternFont);
             }
         }
 
         if (auto* comboBox = qobject_cast<QComboBox*>(widget)) {
             if (auto* view = comboBox->view()) {
                 view->setPalette(widgetPalette);
-                view->setFont(patternFont);
             }
         }
 
@@ -135,6 +131,7 @@ void dlgTriggerPatternEdit::applyThemePalette(const QPalette& editorPalette)
         }
 
         if (auto* plainTextEdit = qobject_cast<QPlainTextEdit*>(widget)) {
+            plainTextEdit->setFont(patternFont);
             if (auto* viewport = plainTextEdit->viewport()) {
                 viewport->setPalette(widgetPalette);
                 viewport->setAutoFillBackground(true);
@@ -144,7 +141,6 @@ void dlgTriggerPatternEdit::applyThemePalette(const QPalette& editorPalette)
             if (auto* viewport = scrollArea->viewport()) {
                 viewport->setPalette(widgetPalette);
                 viewport->setAutoFillBackground(true);
-                viewport->setFont(patternFont);
             }
         }
     };
@@ -157,7 +153,6 @@ void dlgTriggerPatternEdit::applyThemePalette(const QPalette& editorPalette)
     applyToWidget(pushButton_bgColor);
     applyToWidget(singleLineTextEdit_pattern);
 
-    singleLineTextEdit_pattern->setFont(patternFont);
     if (auto* patternViewport = singleLineTextEdit_pattern->viewport()) {
         patternViewport->setFont(patternFont);
     }


### PR DESCRIPTION
## Summary
- keep trigger pattern controls using the application font while preserving the pattern editor font
- stop forcing color and prompt widgets to inherit the pattern font when applying the editor theme

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e22c6ea30c832bb84c10578aae7c80