### PR TITLE
Restore default fonts for trigger pattern controls

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -1202,8 +1202,6 @@ void dlgTriggerEditor::createPatternItem(int index)
 
     lineEditShouldMarkSpaces[pItem->singleLineTextEdit_pattern] = false;
 
-    QFont patternFont = mpHost->getDisplayFont();
-    pItem->singleLineTextEdit_pattern->setFont(patternFont);
     pItem->singleLineTextEdit_pattern->installEventFilter(this);
     pItem->singleLineTextEdit_pattern->setTheme(mpHost->mEditorTheme);
     pItem->applyThemePalette(pItem->singleLineTextEdit_pattern->palette());

--- a/src/dlgTriggerPatternEdit.cpp
+++ b/src/dlgTriggerPatternEdit.cpp
@@ -30,7 +30,6 @@
 #include <QPlainTextEdit>
 #include <QColor>
 #include <QComboBox>
-#include <QFont>
 #include <QLineEdit>
 #include <QPalette>
 #include <QWidget>
@@ -45,6 +44,7 @@ dlgTriggerPatternEdit::dlgTriggerPatternEdit(QWidget* pParentWidget)
     mDefaultPalette = palette();
     mDefaultPatternNumberPalette = label_patternNumber->palette();
     mDefaultPromptPalette = label_prompt->palette();
+    mDefaultColorIconPalette = label_colorIcon->palette();
     mDefaultComboPalette = comboBox_patternType->palette();
     mDefaultSpinPalette = spinBox_lineSpacer->palette();
     mDefaultForegroundButtonPalette = pushButton_fgColor->palette();
@@ -75,9 +75,6 @@ void dlgTriggerPatternEdit::applyThemePalette(const QPalette& editorPalette)
         return;
     }
 
-    const QFont patternFont = singleLineTextEdit_pattern->font();
-    setFont(patternFont);
-    
     auto makePalette = [&](QPalette palette) {
         const QColor alternateBase = editorPalette.color(QPalette::AlternateBase).isValid() ? editorPalette.color(QPalette::AlternateBase) : baseColor;
         const QColor buttonColor = editorPalette.color(QPalette::Button).isValid() ? editorPalette.color(QPalette::Button) : baseColor;
@@ -114,19 +111,16 @@ void dlgTriggerPatternEdit::applyThemePalette(const QPalette& editorPalette)
     auto applyToWidget = [&](QWidget* widget) {
         QPalette widgetPalette = makePalette(editorPalette);
         widget->setPalette(widgetPalette);
-        widget->setFont(patternFont);
 
         if (auto* spinBox = qobject_cast<QAbstractSpinBox*>(widget)) {
             if (auto* lineEdit = spinBox->findChild<QLineEdit*>()) {
                 lineEdit->setPalette(widgetPalette);
-                lineEdit->setFont(patternFont);
             }
         }
 
         if (auto* comboBox = qobject_cast<QComboBox*>(widget)) {
             if (auto* view = comboBox->view()) {
                 view->setPalette(widgetPalette);
-                view->setFont(patternFont);
             }
         }
 
@@ -138,29 +132,24 @@ void dlgTriggerPatternEdit::applyThemePalette(const QPalette& editorPalette)
             if (auto* viewport = plainTextEdit->viewport()) {
                 viewport->setPalette(widgetPalette);
                 viewport->setAutoFillBackground(true);
-                viewport->setFont(patternFont);
             }
         } else if (auto* scrollArea = qobject_cast<QAbstractScrollArea*>(widget)) {
             if (auto* viewport = scrollArea->viewport()) {
                 viewport->setPalette(widgetPalette);
                 viewport->setAutoFillBackground(true);
-                viewport->setFont(patternFont);
             }
         }
     };
 
     applyToWidget(label_patternNumber);
     applyToWidget(label_prompt);
+    applyToWidget(label_colorIcon);
     applyToWidget(comboBox_patternType);
     applyToWidget(spinBox_lineSpacer);
     applyToWidget(pushButton_fgColor);
     applyToWidget(pushButton_bgColor);
     applyToWidget(singleLineTextEdit_pattern);
 
-    singleLineTextEdit_pattern->setFont(patternFont);
-    if (auto* patternViewport = singleLineTextEdit_pattern->viewport()) {
-        patternViewport->setFont(patternFont);
-    }
 }
 
 void dlgTriggerPatternEdit::resetThemePalette()
@@ -170,6 +159,7 @@ void dlgTriggerPatternEdit::resetThemePalette()
 
     label_patternNumber->setPalette(mDefaultPatternNumberPalette);
     label_prompt->setPalette(mDefaultPromptPalette);
+    label_colorIcon->setPalette(mDefaultColorIconPalette);
     comboBox_patternType->setPalette(mDefaultComboPalette);
     spinBox_lineSpacer->setPalette(mDefaultSpinPalette);
     pushButton_fgColor->setPalette(mDefaultForegroundButtonPalette);

--- a/src/dlgTriggerPatternEdit.h
+++ b/src/dlgTriggerPatternEdit.h
@@ -53,6 +53,7 @@ private:
     QPalette mDefaultPalette;
     QPalette mDefaultPatternNumberPalette;
     QPalette mDefaultPromptPalette;
+    QPalette mDefaultColorIconPalette;
     QPalette mDefaultComboPalette;
     QPalette mDefaultSpinPalette;
     QPalette mDefaultForegroundButtonPalette;


### PR DESCRIPTION
## Summary
- stop forcing the trigger pattern controls to use the display font so they inherit the editor's default font
- keep palette updates for the pattern widgets while restoring each control's saved default palette when resetting

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e22c6ea30c832bb84c10578aae7c80