### PR TITLE
Align trigger pattern widgets with input styling

### DIFF
--- a/src/dlgTriggerEditor.cpp
+++ b/src/dlgTriggerEditor.cpp
@@ -62,6 +62,7 @@
 #include <QMargins>
 #include <QMessageBox>
 #include <QMetaEnum>
+#include <QPalette>
 #include <QPoint>
 #include <QScrollBar>
 #include <QShortcut>
@@ -1158,10 +1159,33 @@ void dlgTriggerEditor::slot_clickedMessageBox(const QString& URL)
 void dlgTriggerEditor::slot_editorThemeChanged()
 {
     for (int i = 0; i < mTriggerPatternEdit.size(); i++) {
-        auto* patternWidget = mTriggerPatternEdit.at(i);
-        patternWidget->singleLineTextEdit_pattern->setTheme(mpHost->mEditorTheme);
-        patternWidget->applyThemePalette(patternWidget->singleLineTextEdit_pattern->palette());
+        applyPatternWidgetStyle(mTriggerPatternEdit.at(i));
     }
+}
+
+void dlgTriggerEditor::applyPatternWidgetStyle(dlgTriggerPatternEdit* patternWidget)
+{
+    if (!patternWidget || !mpHost) {
+        return;
+    }
+
+    QPalette referencePalette;
+    QFont referenceFont;
+    bool hasReference = false;
+
+    if (mpTriggersMainArea && mpTriggersMainArea->lineEdit_trigger_name) {
+        referencePalette = mpTriggersMainArea->lineEdit_trigger_name->palette();
+        referenceFont = mpTriggersMainArea->lineEdit_trigger_name->font();
+        hasReference = true;
+    }
+
+    patternWidget->singleLineTextEdit_pattern->setTheme(mpHost->mEditorTheme);
+    if (!hasReference) {
+        referencePalette = patternWidget->singleLineTextEdit_pattern->palette();
+        referenceFont = mpHost->getDisplayFont();
+    }
+    patternWidget->applyThemePalette(referencePalette);
+    patternWidget->singleLineTextEdit_pattern->setFont(referenceFont);
 }
 
 void dlgTriggerEditor::createPatternItem(int index)
@@ -1202,11 +1226,8 @@ void dlgTriggerEditor::createPatternItem(int index)
 
     lineEditShouldMarkSpaces[pItem->singleLineTextEdit_pattern] = false;
 
-    QFont patternFont = mpHost->getDisplayFont();
-    pItem->singleLineTextEdit_pattern->setFont(patternFont);
     pItem->singleLineTextEdit_pattern->installEventFilter(this);
-    pItem->singleLineTextEdit_pattern->setTheme(mpHost->mEditorTheme);
-    pItem->applyThemePalette(pItem->singleLineTextEdit_pattern->palette());
+    applyPatternWidgetStyle(pItem);
     pItem->spinBox_lineSpacer->installEventFilter(this);
 }
 

--- a/src/dlgTriggerEditor.h
+++ b/src/dlgTriggerEditor.h
@@ -477,6 +477,7 @@ private:
     void updatePatternPlaceholders();
     [[nodiscard]] QString patternPlaceholderText(int patternType) const;
     void handlePatternChange(dlgTriggerPatternEdit* patternItem, bool hasContentHint);
+    void applyPatternWidgetStyle(dlgTriggerPatternEdit* patternWidget);
 
     void keyGrabCallback(const Qt::Key, const Qt::KeyboardModifiers);
     void setShortcuts(const bool active = true);

--- a/src/dlgTriggerPatternEdit.cpp
+++ b/src/dlgTriggerPatternEdit.cpp
@@ -74,77 +74,46 @@ void dlgTriggerPatternEdit::applyThemePalette(const QPalette& editorPalette)
         return;
     }
 
-    if (baseColor.lightness() >= textColor.lightness()) {
-        resetThemePalette();
-        return;
-    }
-
-    auto makePalette = [&](QPalette palette) {
-        const QColor alternateBase = editorPalette.color(QPalette::AlternateBase).isValid() ? editorPalette.color(QPalette::AlternateBase) : baseColor;
-        const QColor buttonColor = editorPalette.color(QPalette::Button).isValid() ? editorPalette.color(QPalette::Button) : baseColor;
-        QColor placeholderColor = editorPalette.color(QPalette::PlaceholderText);
-        if (!placeholderColor.isValid()) {
-            placeholderColor = textColor;
-            placeholderColor.setAlphaF(0.6);
-        }
-
-        palette.setColor(QPalette::Window, baseColor);
-        palette.setColor(QPalette::Base, baseColor);
-        palette.setColor(QPalette::AlternateBase, alternateBase);
-        palette.setColor(QPalette::Button, buttonColor);
-        palette.setColor(QPalette::WindowText, textColor);
-        palette.setColor(QPalette::Text, textColor);
-        palette.setColor(QPalette::ButtonText, textColor);
-        palette.setColor(QPalette::PlaceholderText, placeholderColor);
-
-        palette.setColor(QPalette::Disabled, QPalette::WindowText, textColor);
-        palette.setColor(QPalette::Disabled, QPalette::Text, textColor);
-        palette.setColor(QPalette::Disabled, QPalette::ButtonText, textColor);
-        palette.setColor(QPalette::Disabled, QPalette::Base, baseColor);
-        palette.setColor(QPalette::Disabled, QPalette::Button, buttonColor);
-        palette.setColor(QPalette::Disabled, QPalette::AlternateBase, alternateBase);
-
-        return palette;
-    };
-
-    const QPalette darkPalette = makePalette(editorPalette);
-
-    setPalette(darkPalette);
-    setAutoFillBackground(true);
+    setPalette(editorPalette);
+    setAutoFillBackground(false);
 
     auto applyToWidget = [&](QWidget* widget) {
-        QPalette widgetPalette = makePalette(editorPalette);
-        widget->setPalette(widgetPalette);
+        if (!widget) {
+            return;
+        }
+
+        widget->setPalette(editorPalette);
 
         if (auto* spinBox = qobject_cast<QAbstractSpinBox*>(widget)) {
             if (auto* lineEdit = spinBox->findChild<QLineEdit*>()) {
-                lineEdit->setPalette(widgetPalette);
+                lineEdit->setPalette(editorPalette);
             }
         }
 
         if (auto* comboBox = qobject_cast<QComboBox*>(widget)) {
             if (auto* view = comboBox->view()) {
-                view->setPalette(widgetPalette);
+                view->setPalette(editorPalette);
             }
         }
 
         if (auto* button = qobject_cast<QAbstractButton*>(widget)) {
-            button->setAutoFillBackground(true);
+            button->setAutoFillBackground(false);
         }
 
         if (auto* plainTextEdit = qobject_cast<QPlainTextEdit*>(widget)) {
             if (auto* viewport = plainTextEdit->viewport()) {
-                viewport->setPalette(widgetPalette);
+                viewport->setPalette(editorPalette);
                 viewport->setAutoFillBackground(true);
             }
         } else if (auto* scrollArea = qobject_cast<QAbstractScrollArea*>(widget)) {
             if (auto* viewport = scrollArea->viewport()) {
-                viewport->setPalette(widgetPalette);
+                viewport->setPalette(editorPalette);
                 viewport->setAutoFillBackground(true);
             }
         }
     };
 
+    applyToWidget(label_colorIcon);
     applyToWidget(label_patternNumber);
     applyToWidget(label_prompt);
     applyToWidget(comboBox_patternType);


### PR DESCRIPTION
## Summary
- update trigger pattern widgets to reuse the palette and font from the trigger name input for consistent styling
- centralize pattern widget styling logic so theme changes keep pattern editors aligned with the rest of the editor UI

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e2410ef648832ba1e971fd77995e52